### PR TITLE
Implement switch hg to lg for recHit

### DIFF
--- a/DataFormats/interface/HGCalTBRecHit.h
+++ b/DataFormats/interface/HGCalTBRecHit.h
@@ -17,23 +17,29 @@ public:
 
 	HGCalTBRecHit();
 	// by default a recHit is greated with no flag
-	HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
+	//	HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
+	HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, double LG2HG, double gainThrE, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
 	/// get the id
 	HGCalTBDetId id() const
 	{
 		return HGCalTBDetId(detid());
 	}
 	/////  bool isRecovered() const;
-	float _energyLow, _energyHigh;
+	float _energyLow, _energyHigh, _energy;
 
-	float energyLow()
+	float energyLow() const
 	{
 		return _energyLow;
 	};
 
-	float energyHigh()
+	float energyHigh() const
 	{
 		return _energyHigh;
+	};
+
+	float energy() const
+	{
+	  return _energy;
 	};
 
 };

--- a/DataFormats/src/HGCalTBRecHit.cc
+++ b/DataFormats/src/HGCalTBRecHit.cc
@@ -7,17 +7,19 @@ HGCalTBRecHit::HGCalTBRecHit() : CaloRecHit()
 }
 
 
-HGCalTBRecHit::HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, uint32_t flags) :
+HGCalTBRecHit::HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, double LG2HG, double gainThrE, uint32_t flags) :
 	CaloRecHit(id, energyHigh, time, flags),
 	_energyLow(energyLow),
 	_energyHigh(energyHigh)
 {
+  if(_energyHigh < gainThrE) _energy = _energyHigh;
+  else _energy = _energyLow * LG2HG;
 
 	///\todo set the default recHit energy to the highGain values unless saturated
 }
 
 std::ostream& operator<<(std::ostream& s, const HGCalTBRecHit& hit)
 {
-	return s << hit.id() << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
+  return s << hit.id() << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
 
 }

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -1,12 +1,11 @@
 <lcgdict>
   <class name="HGCalTBTrack" ClassVersion="0">
    <version ClassVersion="0" checksum="2994556361"/>
-	</class>
+  </class>
   <class name="std::vector<HGCalTBTrack>"/>
   <class name="edm::Wrapper<vector<HGCalTBTrack> >"/>
-
-  <class name="HGCalTBRecHit" ClassVersion="0">
-   <version ClassVersion="0" checksum="3094752182"/>
+  <class name="HGCalTBRecHit" ClassVersion="-1">
+   <version ClassVersion="-1" checksum="2098716783"/>
   </class>
   <class name="std::vector<HGCalTBRecHit>"/>
   <class name="edm::SortedCollection<HGCalTBRecHit,edm::StrictWeakOrdering<HGCalTBRecHit> >"/>

--- a/RawToDigi/plugins/HGCalTBRawToDigi.cc
+++ b/RawToDigi/plugins/HGCalTBRawToDigi.cc
@@ -126,7 +126,9 @@ void HGCalTBRawToDigi::produce(edm::Event& e, const edm::EventSetup& c)
 					if(ski <= 32) {
 						int ptradc1 = ptr - ichan * 2 - (ski - ski_down);
 						int ptradc2 = ptr - ichan * 2 - (ski - ski_down) -  128;
-						digis->backDataFrame().setSample(0, gray_to_binary(pdata[ptradc1] & 0xFFF), gray_to_binary( pdata[ptradc2] & 0xFFF), 0);
+						if((pdata[ptradc1] != 0xFFFF) && (pdata[ptradc2] != 0xFFFF)){
+							digis->backDataFrame().setSample(0, gray_to_binary(pdata[ptradc1] & 0xFFF), gray_to_binary( pdata[ptradc2] & 0xFFF), 0);
+							}
 //                                        cout<<endl<<dec<<"SKI= "<<ski<<" chan= "<<ichan<<" "<<ptradc1<<" "<<ptradc2<<" "<<" High= "<<hex<<(pdata[ptradc1])<<dec<<"  "<<gray_to_binary(pdata[ptradc1] & 0xFFF)<<" Low= "<<hex<<( pdata[ptradc2] & 0xFFF)<<"  "<<dec<<gray_to_binary( pdata[ptradc2] & 0xFFF)<<endl;
 					}
 

--- a/RawToDigi/plugins/HGCalTBTextSource.cc
+++ b/RawToDigi/plugins/HGCalTBTextSource.cc
@@ -5,6 +5,7 @@
 using namespace std;
 unsigned int runcounter = 0;
 int runflag = 0;
+int DangerFlag = 0;// Catch Danger and push back -10000
 int trigcountperspillflag = 0;
 unsigned int Events_Per_Spill = 0;
 unsigned int spillcounter = 0;
@@ -14,7 +15,7 @@ unsigned int tmp_event = 0;
 int Number_Of_SKIROC_Data_Words = 64;
 int Number_Of_SKIROC_Words = 68;
 
-string buffer1 = "0 0 0x00000000   0x00000000";
+string buffer1 = "0 0 0xFFFFFFFF   0xFFFFFFFF";
 bool HGCalTBTextSource::readLines()
 {
 	m_lines.clear();
@@ -70,12 +71,21 @@ bool HGCalTBTextSource::readLines()
 		                if(strstr(buffer,"CKOV= 1")) cout<<endl<<"CKOV= 1"<<endl;
 		                else cout<<endl<<"CKOV= 0"<<endl;
 		*/
+
 		if(sscanf(buffer, "Event header for event %x with (200ns) timestamp %x", &tmp_event, &m_time) == 2) {
+			DangerFlag = 0;
 			continue;
 		}
+
+		if(sscanf(buffer, "DANGER: stale event warning! Event header for event %x with (200ns) timestamp %x", &tmp_event, &m_time) == 2){
+			DangerFlag = 1;
+			continue;
+		}	
+
 //                if(strstr(buffer, "Event")) continue;
 		counter++;
-		if(runcounter < EVENTSPERSPILL && counter <= Number_Of_SKIROC_Data_Words) m_lines.push_back(buffer);
+		if((DangerFlag == 0) && runcounter < EVENTSPERSPILL && counter <= Number_Of_SKIROC_Data_Words) m_lines.push_back(buffer);
+                if((DangerFlag == 1) && runcounter < EVENTSPERSPILL && counter <= Number_Of_SKIROC_Data_Words) m_lines.push_back(buffer1);
 		if(runcounter < EVENTSPERSPILL && counter == Number_Of_SKIROC_Words) {
 			runcounter++;
 //                   cout<<endl<<" Reached Here 1"<<endl;

--- a/Reco/plugins/HGCalTBRecHitProducer.cc
+++ b/Reco/plugins/HGCalTBRecHitProducer.cc
@@ -6,7 +6,9 @@ HGCalTBRecHitProducer::HGCalTBRecHitProducer(const edm::ParameterSet& cfg)
 	  _pedestalLow_filename(cfg.getParameter<std::string>("pedestalLow")),
 	  _pedestalHigh_filename(cfg.getParameter<std::string>("pedestalHigh")),
 	  _gainsLow_filename(cfg.getParameter<std::string>("gainLow")),
-	  _gainsHigh_filename(cfg.getParameter<std::string>("gainHigh"))
+	  _gainsHigh_filename(cfg.getParameter<std::string>("gainHigh")),
+	  _LG2HG_value(cfg.getParameter<double>("LG2HG")),
+	  _gainThr_value(cfg.getParameter<double>("gainThr"))
 {
 	produces <HGCalTBRecHitCollection>(outputCollectionName);
 
@@ -64,7 +66,8 @@ void HGCalTBRecHitProducer::produce(edm::Event& event, const edm::EventSetup& iS
 			float energyLow = digi[iSample].adcLow() - pedestal_low_value * adcToGeV_low_value;
 			float energyHigh = digi[iSample].adcHigh() - pedestal_high_value * adcToGeV_high_value;
 
-			HGCalTBRecHit recHit(digi.detid(), energyLow, energyHigh, digi[iSample].tdc()); ///\todo use time calibration!
+			//			HGCalTBRecHit recHit(digi.detid(), energyLow, energyHigh, digi[iSample].tdc()); ///\todo use time calibration!
+			HGCalTBRecHit recHit(digi.detid(), energyLow, energyHigh, digi[iSample].tdc(), _LG2HG_value, _gainThr_value * adcToGeV_high_value); ///\todo use time calibration!
 
 #ifdef DEBUG
 			std::cout << recHit << std::endl;

--- a/Reco/plugins/HGCalTBRecHitProducer.h
+++ b/Reco/plugins/HGCalTBRecHitProducer.h
@@ -40,6 +40,7 @@ private:
 	edm::EDGetTokenT<HGCalTBDigiCollection> _digisToken;
 	std::string _pedestalLow_filename, _pedestalHigh_filename;
 	std::string _gainsLow_filename, _gainsHigh_filename;
+	double _LG2HG_value, _gainThr_value;
 };
 
 

--- a/Reco/plugins/RecHitPlotter_HighGain_Correlation_CM.cc
+++ b/Reco/plugins/RecHitPlotter_HighGain_Correlation_CM.cc
@@ -209,7 +209,7 @@ RecHitPlotter_HighGain_Correlation_CM::analyze(const edm::Event& event, const ed
 //             double iyy = (CellCentreXY.second < 0 ) ? (CellCentreXY.second + delta) : (CellCentreXY.second - delta);
 //               Cell_counter++;
 //               Average_Pedestal_Per_Event_Full += RecHit1.energyHigh();
-//               if(RecHit1.energyHigh() > 100) continue;
+               if(RecHit1.energyHigh() > 32.) continue;
 		if((RecHit1.id()).cellType() == 0) {
 //                       Full_Cell[(RecHit1.id()).layer() - 1]->Fill(RecHit1.energyHigh());
 			Cell_counter[(RecHit1.id()).layer() - 1]++;
@@ -245,7 +245,7 @@ RecHitPlotter_HighGain_Correlation_CM::analyze(const edm::Event& event, const ed
 	}
 
 	for(auto RecHit : *Rechits) {
-//                if(RecHit.energyHigh() > 100) continue;
+//                if(RecHit.energyHigh() > 32.) continue;
 		if(!IsCellValid.iu_iv_valid((RecHit.id()).layer(), (RecHit.id()).sensorIU(), (RecHit.id()).sensorIV(), (RecHit.id()).iu(), (RecHit.id()).iv(), sensorsize))  continue;
 		CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots((RecHit.id()).layer(), (RecHit.id()).sensorIU(), (RecHit.id()).sensorIV(), (RecHit.id()).iu(), (RecHit.id()).iv(), sensorsize);
 //                double iux = (CellCentreXY.first < 0 ) ? (CellCentreXY.first + delta) : (CellCentreXY.first - delta) ;

--- a/Reco/python/hgcaltbrechitproducer_cfi.py
+++ b/Reco/python/hgcaltbrechitproducer_cfi.py
@@ -7,5 +7,6 @@ hgcaltbrechits = cms.EDProducer("HGCalTBRecHitProducer",
                                 pedestalHigh = cms.string('CondObjects/data/Ped_HighGain_L8.txt'),
                                 gainLow = cms.string(''),
                                 gainHigh = cms.string(''),
+                                LG2HG = cms.double(9.),
+                                gainThr = cms.double(1800.)
                                 )
-

--- a/syncroH4/H4treeRecoWC.cc
+++ b/syncroH4/H4treeRecoWC.cc
@@ -1,0 +1,125 @@
+#include "H4treeRecoWC.h"
+
+#include <iostream>
+
+#include "TChain.h"
+#include "TString.h"
+
+//#define DEBUG_VERBOSE
+
+//
+H4treeRecoWC::H4treeRecoWC(TChain *tree, TString outUrl):
+  H4treeWC(tree), MaxTdcChannels_(16), MaxTdcReadings_(20)
+{
+  fOut_  = TFile::Open(outUrl,"RECREATE");
+  recoT_ = new TTree("H4treeRecoWC","H4treeRecoWC");
+  recoT_->SetDirectory(fOut_);
+
+  //event header
+  recoT_->Branch("runNumber",    &runNumber,    "runNumber/i");
+  recoT_->Branch("spillNumber",  &spillNumber,  "spillNumber/i");
+  recoT_->Branch("evtNumber",    &evtNumber,    "evtNumber/i");
+  recoT_->Branch("evtTimeDist",  &evtTimeDist,  "evtTimeDist/i");
+  recoT_->Branch("evtTimeStart", &evtTimeStart, "evtTimeStart/i");
+  recoT_->Branch("nEvtTimes",    &nEvtTimes,    "nEvtTimes/i");
+
+  //TDC 
+  tdc_readings_.resize(MaxTdcChannels_);
+  recoT_->Branch("nwc",       &nwc_,      "nwc/i");
+  recoT_->Branch("wc_recox",   wc_recox_, "wc_recox[nwc]/F");
+  recoT_->Branch("wc_recoy",   wc_recoy_, "wc_recoy[nwc]/F");
+  recoT_->Branch("wc_xl_hits",   wc_xl_hits_, "wc_xl_hits[nwc]/i");
+  recoT_->Branch("wc_xr_hits",   wc_xr_hits_, "wc_xr_hits[nwc]/i");
+  recoT_->Branch("wc_yu_hits",   wc_yu_hits_, "wc_yu_hits[nwc]/i");
+  recoT_->Branch("wc_yd_hits",   wc_yd_hits_, "wc_yd_hits[nwc]/i");
+
+  InitDigi();
+}
+
+void H4treeRecoWC::FillEvent()
+{
+  recoT_->Fill();
+}
+
+//
+void H4treeRecoWC::InitDigi()
+{
+  //WCD map                                                                                                                                                                 
+  std::map<std::string, int> WCD_channel;
+  WCD_channel["l"] = 0;
+  WCD_channel["r"] = 1;
+  WCD_channel["d"] = 2;
+  WCD_channel["u"] = 3;
+
+  //WCE map                                                                                                                                                                 
+  std::map<std::string, int> WCE_channel;
+  WCE_channel["l"] = 4;
+  WCE_channel["r"] = 5;
+  WCE_channel["d"] = 6;
+  WCE_channel["u"] = 7;
+
+  std::vector< std::map<std::string, int>  > WC;
+  // 0 == WCD                                                                                                                                                               
+  WC.push_back(WCD_channel);
+  WC.push_back(WCE_channel);
+
+
+  nwc_ = WC.size();
+  for(size_t i=0; i<WC.size(); ++i){
+    wcXl_[i] = WC.at(i)["l"];
+    wcXr_[i] = WC.at(i)["r"];
+    wcYd_[i] = WC.at(i)["d"];
+    wcYu_[i] = WC.at(i)["u"];
+  }
+}
+
+
+
+void H4treeRecoWC::FillTDC()
+{
+  //reset data  
+  for (uint j=0; j<MaxTdcChannels_; j++){ tdc_readings_[j].clear();}
+
+  //fill with new data 
+  for (uint i=0; i<nTdcChannels; i++)
+    {
+      if (tdcChannel[i]<MaxTdcChannels_)
+        {
+          tdc_readings_[tdcChannel[i]].push_back((float)tdcData[i]);
+        }
+    }
+  
+  //compute average positions
+  for(UInt_t iwc=0; iwc<nwc_; iwc++)
+    {
+      //default values in case no tdc data available  
+      wc_recox_[iwc]=-999;
+      wc_recoy_[iwc]=-999;
+      
+      wc_xl_hits_[iwc]=tdc_readings_[wcXl_[iwc]].size();
+      wc_xr_hits_[iwc]=tdc_readings_[wcXr_[iwc]].size();
+      wc_yu_hits_[iwc]=tdc_readings_[wcYu_[iwc]].size();
+      wc_yd_hits_[iwc]=tdc_readings_[wcYd_[iwc]].size();
+
+      if (tdc_readings_[wcXl_[iwc]].size()!=0 && tdc_readings_[wcXr_[iwc]].size()!=0){
+	float TXl = *std::min_element(tdc_readings_[wcXl_[iwc]].begin(),tdc_readings_[wcXl_[iwc]].begin()+tdc_readings_[wcXl_[iwc]].size());
+	float TXr = *std::min_element(tdc_readings_[wcXr_[iwc]].begin(),tdc_readings_[wcXr_[iwc]].begin()+tdc_readings_[wcXr_[iwc]].size());
+	wc_recox_[iwc] = (TXr-TXl)*0.005; // = /40./5./10. //position in cm 0.2mm/ns with 25ps LSB TDC                                                 
+      }
+      if (tdc_readings_[wcYd_[iwc]].size()!=0 && tdc_readings_[wcYu_[iwc]].size()!=0){
+	float TYd = *std::min_element(tdc_readings_[wcYd_[iwc]].begin(),tdc_readings_[wcYd_[iwc]].begin()+tdc_readings_[wcYd_[iwc]].size());
+	float TYu = *std::min_element(tdc_readings_[wcYu_[iwc]].begin(),tdc_readings_[wcYu_[iwc]].begin()+tdc_readings_[wcYu_[iwc]].size());
+	wc_recoy_[iwc] = (TYu-TYd)*0.005; // = /40./5./10. //position in cm 0.2mm/ns with 25ps LSB TDC 
+      }
+    }
+}
+
+
+
+H4treeRecoWC::~H4treeRecoWC()
+{
+  fOut_->cd();
+  std::cout << " recoT_->GetEntries() = " << recoT_->GetEntries() << std::endl;
+  recoT_->Write();
+  fOut_->Close();
+}

--- a/syncroH4/H4treeRecoWC.h
+++ b/syncroH4/H4treeRecoWC.h
@@ -1,0 +1,52 @@
+#ifndef H4treeRecoWC_h
+#define H4treeRecoWC_h
+
+#include "H4treeWC.h"
+
+#include "TFile.h"
+#include "TRandom.h"
+#include "TString.h"
+#include "TChain.h"
+
+#include <set>
+
+class H4treeRecoWC : public H4treeWC
+{
+
+ public:
+
+  H4treeRecoWC(TChain *, TString outUrl="H4treeRecoWCOut.root");
+  void FillEvent();   // (UInt_t evN, ULong64_t evT); 
+  void FillTDC();
+  void InitDigi();
+
+  inline float timeSampleUnit(int drs4Freq)
+  {
+    if (drs4Freq == 0)
+      return 0.2E-9;
+    else if (drs4Freq == 1)
+      return 0.4E-9;
+    else if (drs4Freq == 2)
+      return 1.E-9;    
+    return -999.;
+  }
+
+
+  ~H4treeRecoWC();  
+
+  //TDC readings
+  UInt_t MaxTdcChannels_, MaxTdcReadings_;
+  std::vector< std::vector<Float_t> > tdc_readings_;
+  Float_t wc_recox_[16], wc_recoy_[16];
+  UInt_t wc_xl_hits_[16], wc_xr_hits_[16], wc_yu_hits_[16], wc_yd_hits_[16]; 
+  UInt_t nwc_,wcXl_[4],wcXr_[4],wcYu_[4],wcYd_[4];
+
+
+ protected:
+  TTree *recoT_;
+  TFile *fOut_;
+
+  // private:
+};
+
+#endif

--- a/syncroH4/H4treeWC.cc
+++ b/syncroH4/H4treeWC.cc
@@ -1,0 +1,125 @@
+#include "H4treeWC.h"
+
+#include <TH2.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+
+// void H4treeWC::Loop()
+// {
+//   if (fChain == 0) return;
+
+//   Long64_t nentries = fChain->GetEntries();
+
+//   Long64_t nbytes = 0, nb = 0;
+//   for (Long64_t jentry=0; jentry<nentries;jentry++) {
+//     Long64_t ientry = LoadTree(jentry);
+//     if (ientry < 0) break;
+//     nb = fChain->GetEntry(jentry);   nbytes += nb;
+//     // if (Cut(ientry) < 0) continue;
+//   }
+// }
+
+H4treeWC::H4treeWC(TChain *tree) : fChain(0) 
+{
+  // if parameter tree is not specified (or zero), connect the file
+  // used to generate this class and read the Tree.
+  if (tree == 0) {
+    TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("root://eoscms//eos/cms/store/group/dpg_ecal/alca_ecalcalib/TimingTB_H2_Jul2015/raw/DataTree/3374/14.root");
+    if (!f || !f->IsOpen()) {
+      f = new TFile("root://eoscms//eos/cms/store/group/dpg_ecal/alca_ecalcalib/TimingTB_H2_Jul2015/raw/DataTree/3374/14.root");
+    }
+    f->GetObject("H4treeWC",tree);
+
+  }
+  Init(tree);
+}
+
+H4treeWC::~H4treeWC()
+{
+  if (!fChain) return;
+  delete fChain->GetCurrentFile();
+}
+
+Int_t H4treeWC::GetEntry(Long64_t entry)
+{
+  // Read contents of entry.
+  if (!fChain) return 0;
+  return fChain->GetEntry(entry);
+}
+
+Int_t H4treeWC::TotEntries()
+{
+  // Read contents of entry.
+  if (!fChain) return 0;
+  return fChain->GetEntries();
+}
+
+Long64_t H4treeWC::LoadTree(Long64_t entry)
+{
+  // Set the environment to read one entry
+  if (!fChain) return -5;
+  Long64_t centry = fChain->LoadTree(entry);
+  if (centry < 0) return centry;
+  if (fChain->GetTreeNumber() != fCurrent) {
+    fCurrent = fChain->GetTreeNumber();
+    //    Notify();
+  }
+  return centry;
+}
+
+void H4treeWC::Init(TChain *tree)
+{
+  // The Init() function is called when the selector needs to initialize
+  // a new tree or chain. Typically here the branch addresses and branch
+  // pointers of the tree will be set.
+  // It is normally not necessary to make changes to the generated
+  // code, but the routine can be extended by the user if needed.
+  // Init() will be called many times when running on PROOF
+  // (once per file to be processed).
+
+  // Set branch addresses and branch pointers
+  if (!tree) return;
+  fChain = tree;
+  fCurrent = -1;
+  fChain->SetMakeClass(1);
+
+  fChain->SetBranchAddress("runNumber", &runNumber, &b_runNumber);
+  fChain->SetBranchAddress("spillNumber", &spillNumber, &b_spillNumber);
+  fChain->SetBranchAddress("evtNumber", &evtNumber, &b_evtNumber);
+  fChain->SetBranchAddress("evtTimeDist", &evtTimeDist, &b_evtTimeDist);
+  fChain->SetBranchAddress("evtTimeStart", &evtTimeStart, &b_evtTimeStart);
+  fChain->SetBranchAddress("nEvtTimes", &nEvtTimes, &b_nEvtTimes);
+  fChain->SetBranchAddress("evtTime", evtTime, &b_evtTime);
+  fChain->SetBranchAddress("evtTimeBoard", evtTimeBoard, &b_evtTimeBoard);
+  fChain->SetBranchAddress("nTdcChannels", &nTdcChannels, &b_nTdcChannels);
+  fChain->SetBranchAddress("tdcBoard", tdcBoard, &b_tdcBoard);
+  fChain->SetBranchAddress("tdcChannel", tdcChannel, &b_tdcChannel);
+  fChain->SetBranchAddress("tdcData", tdcData, &b_tdcData);
+  //  Notify();
+}
+
+// Bool_t H4treeWC::Notify()
+// {
+//   // The Notify() function is called when a new file is opened. This
+//   // can be either for a new TTree in a TChain or when when a new TTree
+//   // is started when using PROOF. It is normally not necessary to make changes
+//   // to the generated code, but the routine can be extended by the
+//   // user if needed. The return value is currently not used.
+
+//   return kTRUE;
+// }
+
+// void H4treeWC::Show(Long64_t entry)
+// {
+//   // Print contents of entry.
+//   // If entry is not specified, print current entry
+//   if (!fChain) return;
+//   fChain->Show(entry);
+// }
+// Int_t ee::Cut(Long64_t entry)
+// {
+//   // This function may be called from Loop.
+//   // returns  1 if entry is accepted.
+//   // returns -1 otherwise.
+//   return 1;
+// }

--- a/syncroH4/H4treeWC.h
+++ b/syncroH4/H4treeWC.h
@@ -1,0 +1,59 @@
+#ifndef H4treeWC_h
+#define H4treeWC_h
+
+#include <TROOT.h>
+#include <TChain.h>
+#include <TString.h>
+#include <TFile.h>
+
+// Header file for the classes stored in the TTree if any.
+// Fixed size dimensions of array or collections stored in the TTree if any.
+
+class H4treeWC {
+ public :
+  TChain         *fChain;   //!pointer to the analyzed TTree or TChain
+  Int_t           fCurrent; //!current Tree number in a TChain
+
+  // Declaration of leaf types
+  UInt_t          runNumber;
+  UInt_t          spillNumber;
+  UInt_t          evtNumber;
+  UInt_t          evtTimeDist;
+  UInt_t          evtTimeStart;
+  UInt_t          nEvtTimes;
+  ULong64_t       evtTime[1];   //[nEvtTimes]
+  UInt_t          evtTimeBoard[1];   //[nEvtTimes]
+
+  UInt_t          nTdcChannels;
+  UInt_t          tdcBoard[22];   //[nTdcChannels]
+  UInt_t          tdcChannel[22];   //[nTdcChannels]
+  UInt_t          tdcData[22];   //[nTdcChannels]
+
+  // List of branches
+  TBranch        *b_runNumber;   //!
+  TBranch        *b_spillNumber;   //!
+  TBranch        *b_evtNumber;   //!
+  TBranch        *b_evtTimeDist;   //!
+  TBranch        *b_evtTimeStart;   //!
+  TBranch        *b_nEvtTimes;   //!
+  TBranch        *b_evtTime;   //!
+  TBranch        *b_evtTimeBoard;   //!
+
+  TBranch        *b_nTdcChannels;   //!
+  TBranch        *b_tdcBoard;   //!
+  TBranch        *b_tdcChannel;   //!
+  TBranch        *b_tdcData;   //!
+
+  H4treeWC(TChain *chain=0);
+  virtual ~H4treeWC();
+
+  virtual Int_t    GetEntry(Long64_t entry);
+  virtual Int_t    TotEntries();
+  virtual Long64_t LoadTree(Long64_t entry);
+  virtual void     Init(TChain *tree);
+  /* virtual void     Loop(); */
+  /* virtual Bool_t   Notify(); */
+  /* virtual void     Show(Long64_t entry = -1); */
+};
+
+#endif

--- a/syncroH4/produceSyncronized.cpp
+++ b/syncroH4/produceSyncronized.cpp
@@ -1,0 +1,137 @@
+//g++ -Wall -o produceSyncronized `root-config --cflags --glibs` H4treeWC.cc H4treeRecoWC.cc produceSyncronized.cpp  
+// ./produceSyncronized   H4run pathToH4_run
+//H4run = folder containing the nSpill.root
+
+#include "TChain.h"
+#include "TFile.h"
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TKey.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TChain.h"
+#include "TH1F.h"
+#include "TF1.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TString.h"
+#include "TCut.h"
+#include "TMath.h"
+#include "TApplication.h"
+#include "TError.h"
+#include "TCanvas.h"
+#include "TGraphErrors.h"
+#include "TPad.h"
+
+#include "H4treeWC.h"
+#include "H4treeRecoWC.h"
+
+
+
+int main(int argc, char** argv){
+
+  std::string H4_run = argv[1];
+  std::string pathToH4_run = argv[2];
+
+  std::cout << " reading H4DAQ run = " << H4_run << std::endl;
+
+  TChain* tree = new TChain("H4tree", ("H4treeRecoWCOut_"+H4_run+".root").c_str());
+  if(argc < 3) tree->Add((H4_run+"/*.root").c_str());
+  else tree->Add((pathToH4_run+"/"+H4_run+"/*.root").c_str());
+
+
+  H4treeRecoWC* H4Recotree = new H4treeRecoWC(tree);
+
+  int nEntries_beam = H4Recotree->TotEntries();
+  std::cout << " >> entries = " << nEntries_beam << std::endl;
+
+  
+  ULong64_t evtTime_prev = 0;
+  ULong64_t evtTime_deltaPrev = 0;
+
+  int countInterSpill = 0;
+  int totInterSpill = 0;
+
+  std::vector<double> evtPerSpill;
+  std::vector<double> dT;
+  std::vector<double> WC_x0;
+  std::vector<double> WC_x1;
+  std::vector<double> WC_y0;
+  std::vector<double> WC_y1;
+
+  evtPerSpill.clear();
+  
+  for(int iBeam=0; iBeam<nEntries_beam; ++iBeam){
+
+    if(iBeam == 0) evtTime_deltaPrev = 0;
+    else  evtTime_prev = H4Recotree->evtTime[0];
+    
+    H4Recotree->GetEntry(iBeam);
+
+    if(iBeam != 0) evtTime_deltaPrev = H4Recotree->evtTime[0] - evtTime_prev;
+    H4Recotree->FillTDC();
+
+    // std::cout << H4Recotree->evtNumber << " \t " << evtTime_deltaPrev << " \t " 
+    // 	      << H4Recotree->wc_recox_[0] << " \t " << H4Recotree->wc_recoy_[0] << " \t " 
+    // 	      << H4Recotree->wc_recox_[1] << " \t " << H4Recotree->wc_recoy_[1] << std::endl;
+
+
+    //    if(iBeam > 0)
+    //    std::cout << iBeam << " \t " << evtTime_deltaPrev << std::endl;
+
+    H4Recotree->FillEvent();
+    dT.push_back(evtTime_deltaPrev);
+    WC_x0.push_back(H4Recotree->wc_recox_[0]);
+    WC_x1.push_back(H4Recotree->wc_recox_[1]);
+    WC_y0.push_back(H4Recotree->wc_recoy_[0]);
+    WC_y1.push_back(H4Recotree->wc_recoy_[1]);
+
+    if(evtTime_deltaPrev > 1.e+06){
+      evtPerSpill.push_back(countInterSpill);
+      countInterSpill = 0;
+    }
+    if(iBeam == nEntries_beam - 1){
+      evtPerSpill.push_back(countInterSpill);
+    }
+
+    ++countInterSpill;
+    ++totInterSpill;
+    
+  } //raw ntuple with WC coded info
+
+
+  //  return 100 ;
+
+  delete H4Recotree;
+
+  unsigned int nSpill = 0;
+  unsigned int evtSpill = evtPerSpill.at(nSpill);
+
+  // write out txt
+  std::ofstream outFile(("WC_H4Run"+H4_run+".txt").c_str(), std::ios::out);
+  outFile << "H4run " << atoi(H4_run.c_str()) << " evtSpill " << evtSpill << std::endl;
+
+  
+  for(unsigned int iEv = 0; iEv < dT.size(); ++iEv){
+
+    if(iEv  == evtSpill && iEv+1 != dT.size()){
+      outFile << "H4run " << atoi(H4_run.c_str()) << " evtSpill " << evtPerSpill.at(nSpill) << std::endl;
+      //std::cout << " fine spill " << nSpill << " nEvt = " << evtSpill << " dEvt = " << evtPerSpill.at(nSpill) << " iEv = " << iEv << " dT = " << dT.at(iEv) << std::endl;
+      if(nSpill < evtPerSpill.size()-1){
+	++nSpill;
+	evtSpill += evtPerSpill.at(nSpill);
+      }
+    }  
+    outFile << WC_x0.at(iEv) << " \t " << WC_x1.at(iEv) << " \t " << WC_y0.at(iEv) << " \t " << WC_y1.at(iEv) << std::endl;
+  }
+  
+  outFile.close();
+
+
+  std::cout << " END " << std::endl;
+}


### PR DESCRIPTION
commit 4d00e5e + 2d3f10b: to include an energy() method for recHit, providing HGenergy and LGenergy\* LG2HG if saturation occurs.
Parameters are passed through Reco/python/hgcaltbrechitproducer_cfi.py.
Also DataFormats/src/classes_def.xml was changed to enable CMSSW to compile.

Commit  d082ba8 is to improve the code structure, adding some interesting distributions and some fixes, no radical changes.
