### PR TITLE
Fix analyzer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -48,3 +48,14 @@ process.TFileService = cms.Service("TFileService", fileName = cms.string("HGC_Ou
 
 
 cmsRun test_cfg.py >> /dev/null
+
+
+** new event-based reco **
+sh scripts/rearrangeTxtFile.sh input.txt
+   >> need fix to rearrange HGCRun type. Produce output.txt
+
+cmsRun test_cfg_newEB.py nSpills=9 chainSequence=6 pedestalsHighGain=CondObjects/data/Ped_HighGain_L8.txt pedestalsLowGain=CondObjects/data/Ped_LowGain_L8.txt runNumber=930 configuration=2 runType=HGCRun
+   >> chainSequence=6 to run Layer_Sum_Analyzer 
+   >> configuration=1 (2) to select weights for 5X0 (25X0) 8 layers cern runs
+   >> test_cfg_newEB.py to be fixed when rearrangeTxtFile.sh works properly
+

--- a/Reco/plugins/Layer_Sum_Analyzer.cc
+++ b/Reco/plugins/Layer_Sum_Analyzer.cc
@@ -50,13 +50,19 @@ const bool PIONS(0);// uses > PION_*CELLS_THRESHOLD and < *CELLS_THRESHOLD
 double Layer_Z[16]  = {1.2, 2., 3.5, 4.3, 5.8, 6.3, 8.7, 9.5, 11.4, 12.2, 13.8, 14.6, 16.6, 17.4, 20., 20.8};
 
 double ADCtoMIP[16] = {1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1. };
+double MIP2ParticleCalib = 1.3;  // FIXME for CERN
 
 //double ADCtoMIP[16] = {16.02,16.85,15.36,14.73,10.66,15.64,16.52,14.24,10.07,14.42,16.14,17.33,16.61,16.84,15.79,16.43};// one MIP is equal to _ADCtoMIP_ ADC Counts
 //double LayerWeight[16] = {0.6374029601923652, 0.7392021202456731, 0.6374273268336504, 0.7392021202456731, 0.6374273268336504, 0.8861075434658853, 0.8487578715427883, 1.0330129666860974, 0.8487578715427883, 1.0330129666860974, 0.8487578715427883, 1.5226977107534714, 1.2714189609610644, 1.5226977107534714, 1.2714189609610644, 1.5226977107534714};// X0 weights
 
 //double LayerWeight[16] = {1.4091566745180932, 0.7020676448403224, 0.6054055986179145, 0.7020676448403224, 0.6054055986179145, 0.8415931435769973, 0.8061197656138868, 0.9811186423136724, 0.8061197656138868, 0.9811186423136724, 0.8061197656138868, 1.4462036381025891, 1.2075480996058319, 1.4462036381025891, 1.2075480996058319, 1.4462036381025891};
 
-double LayerWeight[16] = {1.};
+
+double LayerWeight_8L_conf1[16] = {33.074, 13.184, 14.17, 9.788, 9.766, 9.766, 16.339, 14.129};
+double X0depth_8L_conf1[16] = {6.268, 1.131, 1.131, 1.362, 0.574, 1.301, 0.574, 2.42};
+double LayerWeight_8L_conf2[16] = {35.866, 30.864, 28.803, 23.095, 20.657, 19.804, 36.322, 27.451};
+double X0depth_8L_conf2[16] = {5.048, 3.412, 3.412, 2.866, 2.512, 1.625, 2.368, 6.021};
+double weights2GeV = 1.e-03;
 
 //double LayerWeight[16] = {0.4847555727337982, 1.0214605968539232, 0.4847555727337982, 1.0214605968539232, 0.4847555727337982, 1.1420105918768606, 0.6423912113800805, 1.2625605868997982, 0.6423912113800805, 1.2625605868997982, 0.6423912113800805, 1.6643939036429232, 0.9576624886726451, 1.6643939036429232, 0.9576624886726451, 1.6643939036429232};// dE/dx weights
 
@@ -91,6 +97,8 @@ private:
 
 	// ----------member data ---------------------------
 	edm::EDGetToken HGCalTBRecHitCollection_;
+        int CERN_8layers_config_;
+
 	struct {
 		HGCalElectronicsMap emap_;
 	} essource_;
@@ -98,28 +106,33 @@ private:
 	int sensorsize = 128;
 	std::vector<std::pair<double, double>> CellXY;
 	std::pair<double, double> CellCentreXY;
+        HGCalTBTopology IsCellValid;
 	HGCalTBCellVertices TheCell;
-	double maxdist = (1 + sqrt (3) / 2) * HGCAL_TB_CELL::FULL_CELL_SIDE;
-	TH1F *h_sum_layer[MAXLAYERS], *h_layer_seven[MAXLAYERS], *h_layer_nineteen[MAXLAYERS], *h_sum_all, *h_seven_all, *h_nineteen_all;
-	TH1F *h_x_layer[MAXLAYERS], *h_y_layer[MAXLAYERS];
+        double maxdist = (1 + sqrt (3) / 2) * HGCAL_TB_CELL::FULL_CELL_SIDE;  // <<< FIXME maxdist > HGCAL_TB_CELL::FULL_CELL_SIDE !!
+
+        double Weights_8L[MAXLAYERS];
+        double X0_8L[MAXLAYERS];
+
+        TH1F *h_CM_layer[MAXSKIROCS];
+	TH1F *h_sum_layer[MAXLAYERS], *h_layer_seven[MAXLAYERS], *h_layer_nineteen[MAXLAYERS], *h_Seed_layer[MAXLAYERS];
+	TH1F *h_sum_layer_AbsW[MAXLAYERS], *h_layer_seven_AbsW[MAXLAYERS], *h_layer_nineteen_AbsW[MAXLAYERS], *h_Seed_layer_AbsW[MAXLAYERS];
+      	TH1F *h_x_layer[MAXLAYERS], *h_y_layer[MAXLAYERS];
 	TH2F *h_x_y_layer[MAXLAYERS];
-        TH1F *h_CM_layer[MAXLAYERS];
-        TH1F *h_Seed_layer[MAXLAYERS];
+
+        TH1F* h_Radius[MAXLAYERS];      
         TH1F *h_E1oE7_layer[MAXLAYERS], *h_E1oE19_layer[MAXLAYERS], *h_E7oE19_layer[MAXLAYERS];
+
+        TH1F *h_sum_all, *h_seven_all, *h_nineteen_all;
+        TH1F *h_sum_all_AbsW, *h_seven_all_AbsW, *h_nineteen_all_AbsW;
         TProfile *tp_E1_vs_layer, *tp_E7_vs_layer, *tp_E19_vs_layer;
         TProfile *tp_E1oSumL_vs_layer, *tp_E7oSumL_vs_layer, *tp_E19oSumL_vs_layer;
         TProfile *tp_E1oE7_vs_layer, *tp_E1oE19_vs_layer, *tp_E7oE19_vs_layer;
 
 	TH2F *HighGain_LowGain_2D;
-	int SPILL = 0, EVENT = 0, LAYER = 0;
+	TH2F *Energy_LowGain_2D;
 
-	map<int, double> CMCells[MAXLAYERS];
-	map<int, double> AllCells[MAXLAYERS];
-	map<int, double> SeedCells[MAXLAYERS];
-	map<int, double> SevenCells[MAXLAYERS];
-	map<int, double> NineteenCells[MAXLAYERS];
-	map<int, double> X_Layer[MAXLAYERS];
-	map<int, double> Y_Layer[MAXLAYERS];
+        int EVENT = 0;
+
 	map<int, double> Time_Stamp;
 	map<int, double> Delta_Time_Stamp;
 	double Time_Temp = 0.;
@@ -129,53 +142,84 @@ private:
 
 Layer_Sum_Analyzer::Layer_Sum_Analyzer(const edm::ParameterSet& iConfig)
 {
-
+  std::cout << " welcome costruttore MAXSKIROCS = " << MAXSKIROCS << std::endl;
 	// initialization
 	usesResource("TFileService");
 	edm::Service<TFileService> fs;
 	HGCalTBRecHitCollection_ = consumes<HGCalTBRecHitCollection>(iConfig.getParameter<edm::InputTag>("HGCALTBRECHITS"));
+	CERN_8layers_config_ = iConfig.getParameter<int>("CERN_8layers_config");
 
 	//booking the histos
 	for(int layer = 0; layer < MAXLAYERS; layer++) {
-	  stringstream name, seedname, sevenname, nineteenname, Xname, Yname, X_Y_name;
-	  name << "AllCells_Sum_Layer" << layer + 1;
-	  seedname << "SeedCell_Layer" << layer + 1;
-	  sevenname << "Cells7_Sum_Layer" << layer + 1;
-	  nineteenname << "Cells19_Sum_Layer" << layer + 1;
-	  Xname << "X_Layer" << layer + 1;
-	  Yname << "Y_Layer" << layer + 1;
-	  X_Y_name << "X_Y_Layer" << layer + 1;
-	  
-	  h_sum_layer[layer] = fs->make<TH1F>(name.str().c_str(), name.str().c_str(), 40010, -10, 40000);
-	  h_layer_seven[layer] = fs->make<TH1F>(sevenname.str().c_str(), sevenname.str().c_str(), 40010, -10, 40000);
-	  h_layer_nineteen[layer] = fs->make<TH1F>(nineteenname.str().c_str(), nineteenname.str().c_str(), 40010, -10, 40000);
-	  h_x_layer[layer] = fs->make<TH1F>(Xname.str().c_str(), Xname.str().c_str(), 2000, -10., 10. );
-	  h_y_layer[layer] = fs->make<TH1F>(Yname.str().c_str(), Yname.str().c_str(), 2000, -10., 10. );
-	  h_x_y_layer[layer] = fs->make<TH2F>(X_Y_name.str().c_str(), X_Y_name.str().c_str(), 2000, -10., 10., 2000, -10., 10. );
-	  h_CM_layer[layer] = fs->make<TH1F>(Form("h_CM_layer%d",layer+1), Form("h_CM_layer%d",layer+1), 5000, -500, 500);
+	  h_sum_layer[layer] = fs->make<TH1F>(Form("sumAll_Layer%d", layer+1), "", 40010, -10, 40000);
 	  h_Seed_layer[layer] = fs->make<TH1F>(Form("h_Seed_layer%d",layer+1), Form("h_Seed_layer%d",layer+1), 40010, -10, 40000);
+	  h_layer_seven[layer] = fs->make<TH1F>(Form("sum7_Layer%d", layer+1),"",  40010, -10, 40000);
+	  h_layer_nineteen[layer] = fs->make<TH1F>(Form("sum19_Layer%d", layer+1), "", 40010, -10, 40000);
+
+	  h_sum_layer_AbsW[layer] = fs->make<TH1F>(Form("sumAll_Layer%d_AbsW", layer+1), "", 40010, -10, 40000);
+	  h_Seed_layer_AbsW[layer] = fs->make<TH1F>(Form("h_Seed_layer%d_AbsW",layer+1), Form("h_Seed_layer%d",layer+1), 40010, -10, 40000);
+	  h_layer_seven_AbsW[layer] = fs->make<TH1F>(Form("sum7_Layer%d_AbsW", layer+1),"",  40010, -10, 40000);
+	  h_layer_nineteen_AbsW[layer] = fs->make<TH1F>(Form("sum19_Layer%d_AbsW", layer+1), "", 40010, -10, 40000);
+
+	  h_x_layer[layer] = fs->make<TH1F>(Form("X_Layer%d", layer+1), "", 2000, -10., 10. );
+	  h_y_layer[layer] = fs->make<TH1F>(Form("Y_Layer%d", layer+1), "", 2000, -10., 10. );
+	  h_x_y_layer[layer] = fs->make<TH2F>(Form("YvsX_Layer%d", layer+1), "", 2000, -10., 10., 2000, -10., 10. );
+
 	  h_E1oE7_layer[layer] = fs->make<TH1F>(Form("h_E1oE7_layer%d",layer+1), Form("h_E1oE7_layer%d",layer+1), 5000, -5, 5);
 	  h_E1oE19_layer[layer] = fs->make<TH1F>(Form("h_E1oE19_layer%d",layer+1), Form("h_E1oE19_layer%d",layer+1), 5000, -5, 5);
 	  h_E7oE19_layer[layer] = fs->make<TH1F>(Form("h_E7oE19_layer%d",layer+1), Form("h_E7oE19_layer%d",layer+1), 5000, -5, 5);
+	  h_Radius[layer] = fs->make<TH1F>(Form("h_Radius_layer%d",layer+1), Form("h_Radius_layer%d",layer+1), 5000, 0., 20.);
 	}
 
-	h_sum_all = fs->make<TH1F>("AllCells_Sum_AllLayers", "AllCells_Sum_AllLayers", 40010, -10, 40000);
+	for(int ski=0; ski<MAXSKIROCS; ++ski) {
+	  h_CM_layer[ski] = fs->make<TH1F>(Form("h_CM_skiroc%d",ski+1), "", 5000, -500, 500);
+	}
+
+	h_sum_all = fs->make<TH1F>("h_sumAll_AllLayers", "", 40010, -10, 40000);
+	h_seven_all = fs->make<TH1F>("h_sum7_AllLayers", "", 40010, -10, 40000);
+	h_nineteen_all = fs->make<TH1F>("h_sum19_AllLayers", "", 40010, -10, 40000);
 	h_sum_all->Sumw2();
-	h_seven_all = fs->make<TH1F>("Cells7_Sum_AllLayers", "7Cells_Sum_AllLayers", 40010, -10, 40000);
 	h_seven_all->Sumw2();
-	h_nineteen_all = fs->make<TH1F>("Cells19_Sum_AllLayers", "19Cells_Sum_AllLayers", 40010, -10, 40000);
 	h_nineteen_all->Sumw2();
-	HighGain_LowGain_2D = fs->make<TH2F>("HighGain_LowGain_2D", "HighGain_LowGain_2D", 4000, 0, 4000, 4000, 0, 4000);
-	tp_E1_vs_layer = fs->make<TProfile>("tp_E1_vs_layer", "tp_E1_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E7_vs_layer = fs->make<TProfile>("tp_E7_vs_layer", "tp_E7_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E19_vs_layer = fs->make<TProfile>("tp_E19_vs_layer", "tp_E19_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E1oSumL_vs_layer = fs->make<TProfile>("tp_E1oSumL_vs_layer", "tp_E1oSumL_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E7oSumL_vs_layer = fs->make<TProfile>("tp_E7oSumL_vs_layer", "tp_E7oSumL_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E19oSumL_vs_layer = fs->make<TProfile>("tp_E19oSumL_vs_layer", "tp_E19oSumL_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E1oE7_vs_layer = fs->make<TProfile>("tp_E1oE7_vs_layer", "tp_E1oE7_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E1oE19_vs_layer = fs->make<TProfile>("tp_E1oE19_vs_layer", "tp_E1oE19_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
-	tp_E7oE19_vs_layer = fs->make<TProfile>("tp_E7oE19_vs_layer", "tp_E7oE19_vs_layer", MAXLAYERS+1, 0, MAXLAYERS+1);
+	h_sum_all_AbsW = fs->make<TH1F>("h_sumAll_AllLayers_AbsW", "", 40010, -10, 40000);
+	h_seven_all_AbsW = fs->make<TH1F>("h_sum7_AllLayers_AbsW", "", 40010, -10, 40000);
+	h_nineteen_all_AbsW = fs->make<TH1F>("h_sum19_AllLayers_AbsW", "", 40010, -10, 40000);
+	h_sum_all_AbsW->Sumw2();
+	h_seven_all_AbsW->Sumw2();
+	h_nineteen_all_AbsW->Sumw2();
+
+	HighGain_LowGain_2D = fs->make<TH2F>("h2_HGvsLG", "", 4000, 0, 4000, 4000, 0, 4000);
+	Energy_LowGain_2D = fs->make<TH2F>("h2_EvsLG", "", 4000, 0, 4000, 4000, 0, 4000);
+
+	tp_E1_vs_layer = fs->make<TProfile>("tp_E1_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E7_vs_layer = fs->make<TProfile>("tp_E7_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E19_vs_layer = fs->make<TProfile>("tp_E19_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E1oSumL_vs_layer = fs->make<TProfile>("tp_E1oSumL_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E7oSumL_vs_layer = fs->make<TProfile>("tp_E7oSumL_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E19oSumL_vs_layer = fs->make<TProfile>("tp_E19oSumL_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E1oE7_vs_layer = fs->make<TProfile>("tp_E1oE7_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E1oE19_vs_layer = fs->make<TProfile>("tp_E1oE19_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
+	tp_E7oE19_vs_layer = fs->make<TProfile>("tp_E7oE19_vs_layer", "", MAXLAYERS+1, 0, MAXLAYERS+1);
 	
+
+        //loading the proper weights
+        if(MAXLAYERS != 8) {
+	  std::cout << " update weights " << std::endl;
+	  return;
+	}
+
+        for(int iL=0; iL<MAXLAYERS; ++iL){
+	  if(CERN_8layers_config_ == 1){
+	    Weights_8L[iL] = LayerWeight_8L_conf1[iL];
+	    X0_8L[iL] = X0depth_8L_conf1[iL];
+	  }
+	  if(CERN_8layers_config_ == 2){
+	    Weights_8L[iL] = LayerWeight_8L_conf2[iL];
+	    X0_8L[iL] = X0depth_8L_conf2[iL]; 
+	  }
+	}
+
+
 }//constructor ends here
 
 
@@ -194,129 +238,223 @@ Layer_Sum_Analyzer::analyze(const edm::Event& event, const edm::EventSetup& setu
 {
 
   //  std::cout << " >>> Layer_Sum_Analyzer::analyze " << std::endl;
+  EVENT = (event.id()).event();
 
-	if(((event.id()).event() - 1) % (EVENTSPERSPILL * MAXLAYERS) == 0 && (event.id()).event() != 1) {
-		SPILL++;
-	}
-	LAYER = (((event.id()).event() - 1) / EVENTSPERSPILL) % MAXLAYERS;
-	EVENT = ((event.id()).event() - 1) % EVENTSPERSPILL + EVENTSPERSPILL * SPILL;
-	if(EVENT == 1) {
-		Time_Temp = event.time().value();
-		Time_Stamp[EVENT] = Time_Temp;
-		Delta_Time_Stamp[EVENT] = 0.;
-	} else {
-		Time_Stamp[EVENT] = event.time().value();
-		Delta_Time_Stamp[EVENT] = event.time().value() - Time_Temp;
-		Time_Temp = event.time().value();
-	}
-	//opening Rechits
-	edm::Handle<HGCalTBRecHitCollection> Rechits;
-	event.getByToken(HGCalTBRecHitCollection_, Rechits);
+  if((event.id()).event() == 1) {
+    Time_Temp = event.time().value();
+    Time_Stamp[EVENT] = Time_Temp;
+    Delta_Time_Stamp[EVENT] = 0.;
+  } else {
+    Time_Stamp[EVENT] = event.time().value();
+    Delta_Time_Stamp[EVENT] = event.time().value() - Time_Temp;
+    Time_Temp = event.time().value();
+  }
+  
+  //opening Rechits
+  edm::Handle<HGCalTBRecHitCollection> Rechits;
+  event.getByToken(HGCalTBRecHitCollection_, Rechits);
+  
+  // looping over each rechit to fill histogram
+  double commonmode[MAXSKIROCS];
+  int cm_num[MAXSKIROCS];
+  for(int iS=0; iS<MAXSKIROCS; ++iS){
+    commonmode[iS] = 0.;
+    cm_num[iS] = 0;
+  }
+  double max[MAXLAYERS], max_x[MAXLAYERS], max_y[MAXLAYERS];
+  for(int iL=0; iL<MAXLAYERS; ++iL){
+    max[iL] = max_x[iL] = max_y[iL] = 0.;
+  }
 
-	// looping over each rechit to fill histogram
-	bool FIRST(1);
-	double commonmode, max, max_x, max_y;
-	commonmode = max = max_x = max_y = 0.;
-	int cm_num = 0;
-	for(auto Rechit : *Rechits) {
+  
+  //CM subtraction => REPLACE WITH EXTERNAL CLASS => FIX
+  for(auto Rechit : *Rechits){
+    
+    if(!IsCellValid.iu_iv_valid((Rechit.id()).layer(), (Rechit.id()).sensorIU(), (Rechit.id()).sensorIV(), (Rechit.id()).iu(), (Rechit.id()).iv(), sensorsize))  continue;
+   
+    //getting electronics ID
+    uint32_t EID = essource_.emap_.detId2eid(Rechit.id());
+    HGCalTBElectronicsId eid(EID);
+    
+    int n_layer = (Rechit.id()).layer() - 1;
+    int n_cell_type = (Rechit.id()).cellType();
+    int n_skiroc = eid.iskiroc() - 1;
 
-	  //getting electronics ID
-	  uint32_t EID = essource_.emap_.detId2eid(Rechit.id());
-	  HGCalTBElectronicsId eid(EID);
+
+    //getting X and Y coordinates
+    CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots((Rechit.id()).layer(), (Rechit.id()).sensorIU(), (Rechit.id()).sensorIV(), (Rechit.id()).iu(), (Rechit.id()).iv(), sensorsize);
+
+    HighGain_LowGain_2D->Fill(Rechit.energyLow(), Rechit.energyHigh());
+    Energy_LowGain_2D->Fill(Rechit.energy(), Rechit.energyHigh());
+    
+    // needed? FIXME
+    if(n_cell_type != 0) continue;
+    
+    if(Rechit.energy() > max[n_layer]) {      
+      max[n_layer] = Rechit.energy();
+      max_x[n_layer] = CellCentreXY.first;
+      max_y[n_layer] = CellCentreXY.second;
+    }
+
+    if((Rechit.energy()) / ADCtoMIP[n_skiroc] <= CMTHRESHOLD) {
+      commonmode[n_skiroc] += Rechit.energy();
+      cm_num[n_skiroc]++;
+    }
+
+  }//Rechit loop ends here
+  //	std::cout << " >>> found commonmode = " << commonmode << std::endl;
+
+
+  for(int iS=0; iS<MAXSKIROCS; ++iS){
+    commonmode[iS] = commonmode[iS]/cm_num[iS];
+    //    std::cout << " value = " << commonmode[iS] << std::endl;
+  }
+
+
+  edm::Handle<HGCalTBRecHitCollection> Rechits1;
+  event.getByToken(HGCalTBRecHitCollection_, Rechits1);
+
+  // looping over each rechit to fill histogram
+  double allcells_sum[MAXLAYERS], sevencells_sum[MAXLAYERS], nineteencells_sum[MAXLAYERS], radius[MAXLAYERS];
+  double seedEnergy[MAXLAYERS];
+  double x_tmp[MAXLAYERS], y_tmp[MAXLAYERS];
+  int num[MAXLAYERS], sevennum[MAXLAYERS], nineteennum[MAXLAYERS];
+
+  for(int iL=0; iL<MAXLAYERS; ++iL){
+    allcells_sum[iL] = sevencells_sum[iL] = nineteencells_sum[iL] = radius[iL] = 0.;
+    x_tmp[iL] = y_tmp[iL] = seedEnergy[iL] = 0.;
+    num[iL] = sevennum[iL] = nineteennum[iL] = 0;
+  }
+
+  for(auto Rechit1 : *Rechits1) {
+
+    if(!IsCellValid.iu_iv_valid((Rechit1.id()).layer(), (Rechit1.id()).sensorIU(), (Rechit1.id()).sensorIV(), (Rechit1.id()).iu(), (Rechit1.id()).iv(), sensorsize))  continue;	  
+    
+    //getting electronics ID
+    uint32_t EID = essource_.emap_.detId2eid(Rechit1.id());
+    HGCalTBElectronicsId eid(EID);
 	  
-	  //getting X and Y coordinates
-	  CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots((Rechit.id()).layer(), (Rechit.id()).sensorIU(), (Rechit.id()).sensorIV(), (Rechit.id()).iu(), (Rechit.id()).iv(), sensorsize);
-	  HighGain_LowGain_2D->Fill(Rechit.energyLow(), Rechit.energyHigh());
-	  if((Rechit.id()).cellType() != 0) continue;
-	  
-	  if(FIRST) {
-	    
-	    max = Rechit.energyHigh();
-	    max_x = CellCentreXY.first;
-	    max_y = CellCentreXY.second;
-	    FIRST = 0;
-	  }
+    int eLayer = (Rechit1.id()).layer()-1;
+    int eCellType = (Rechit1.id()).cellType();
+    int eSkiroc = eid.iskiroc() - 1;
 
-		if(Rechit.energyHigh() > max) {
 
-			max = Rechit.energyHigh();
-			max_x = CellCentreXY.first;
-			max_y = CellCentreXY.second;
-		}
+    //getting X and Y coordinates
+    CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots((Rechit1.id()).layer(), (Rechit1.id()).sensorIU(), (Rechit1.id()).sensorIV(), (Rechit1.id()).iu(), (Rechit1.id()).iv(), sensorsize);
 
-		if((Rechit.energyHigh()) / ADCtoMIP[LAYER] <= CMTHRESHOLD) {
+    //FIXME >> needed?
+    if(eCellType != 0) continue;
 
-			commonmode += Rechit.energyHigh();
-			cm_num++;
-		}
+    //    std::cout << Rechit1.energy() << std::endl;
 
-	}//Rechit loop ends here
-	//	std::cout << " >>> found commonmode = " << commonmode << std::endl;
-	commonmode /= cm_num;
+    radius[eLayer] = sqrt( pow(CellCentreXY.first - max_x[eLayer], 2) + pow(CellCentreXY.second - max_y[eLayer], 2) );
 
-	edm::Handle<HGCalTBRecHitCollection> Rechits1;
-	event.getByToken(HGCalTBRecHitCollection_, Rechits1);
+    float energyCMsub = (Rechit1.energy() - commonmode[eSkiroc]) / ADCtoMIP[eSkiroc];
+    //    std::cout << "val = " << commonmode[eSkiroc] << std::endl;
+    if(energyCMsub > CMTHRESHOLD){
+      allcells_sum[eLayer] += energyCMsub;
+      if(energyCMsub > seedEnergy[eLayer]) seedEnergy[eLayer] = energyCMsub;
+    }
+    
+    // countin all recHits even below CM threshold
+    num[eLayer]++;
 
-	// looping over each rechit to fill histogram
-	double allcells_sum, sevencells_sum, nineteencells_sum, radius;
-	allcells_sum = sevencells_sum = nineteencells_sum = radius = 0.;
-	double seedEnergy = -1.;
-	double x_tmp = 0., y_tmp = 0.;
-	int num, sevennum, nineteennum;
-	num = sevennum = nineteennum = 0;
-	for(auto Rechit1 : *Rechits1) {
-
-		//getting electronics ID
-		uint32_t EID = essource_.emap_.detId2eid(Rechit1.id());
-		HGCalTBElectronicsId eid(EID);
-
-		//getting X and Y coordinates
-		CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots((Rechit1.id()).layer(), (Rechit1.id()).sensorIU(), (Rechit1.id()).sensorIV(), (Rechit1.id()).iu(), (Rechit1.id()).iv(), sensorsize);
-
-		if((Rechit1.id()).cellType() != 0) continue;
-
-		radius = sqrt( pow(CellCentreXY.first - max_x, 2) + pow(CellCentreXY.second - max_y, 2) );
-
-		if(((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER]) > CMTHRESHOLD){
-		  allcells_sum += (Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER];
-		  if(seedEnergy == -1) seedEnergy = (Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER];
-		  else{
-		    if((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER] > seedEnergy) seedEnergy = (Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER];
-		  }
-		}
-
-		// countin all recHits even below CM threshold
-		num++;
+    h_Radius[eLayer]->Fill(radius[eLayer]);
 		
-		if((radius < maxdist && sevennum < 7) && ((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER] > CMTHRESHOLD)) {
+    //FIXME navigation to 7cells
+    if((radius[eLayer] < maxdist && sevennum[eLayer] < 7) && (energyCMsub > CMTHRESHOLD)){
+      sevencells_sum[eLayer] += energyCMsub;
+      sevennum[eLayer]++;
+    }
 
-			sevencells_sum += (Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER];
-			sevennum++;
-		}
-
-		if((radius < 1.95 * maxdist && nineteennum < 19) && ((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER] > CMTHRESHOLD)) {
-
+    //FIXME navigation to 19cells
+    if((radius[eLayer] < 1.95 * maxdist && nineteennum[eLayer] < 19) && (energyCMsub > CMTHRESHOLD)){
 //			nineteencells_sum += (LayerWeight[LAYER]*(Rechit1.energyHigh() - commonmode))/ ADCtoMIP[LAYER];
-			nineteencells_sum += ((Rechit1.energyHigh() - commonmode)) / ADCtoMIP[LAYER];
+      nineteencells_sum[eLayer] += energyCMsub;
+      x_tmp[eLayer] += CellCentreXY.first * energyCMsub;
+      y_tmp[eLayer] += CellCentreXY.second * energyCMsub;
+      nineteennum[eLayer]++;
+    }
+  }
 
-			x_tmp += CellCentreXY.first * ((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER]);
-			y_tmp += CellCentreXY.second * ((Rechit1.energyHigh() - commonmode) / ADCtoMIP[LAYER]);
-			nineteennum++;
-		}
-	}
-	//	std::cout << " >>> all rechits = " << num << " sevennum = " << sevennum << " nineteennum = " << nineteennum << std::endl;
+  for(int iS=0; iS<MAXSKIROCS; ++iS){
+    //    std::cout << "iS = " << iS << " CM = " << commonmode[iS] << std::endl; 
+    h_CM_layer[iS]->Fill(commonmode[iS]);
+  }
+ 
 
-	CMCells[LAYER][EVENT] = commonmode;
-	AllCells[LAYER][EVENT] = allcells_sum;
-	SeedCells[LAYER][EVENT] = seedEnergy;
-	SevenCells[LAYER][EVENT] = sevencells_sum;
-	NineteenCells[LAYER][EVENT] = nineteencells_sum;
-	if(nineteennum > 1 &&  nineteencells_sum > 0) X_Layer[LAYER][EVENT] = x_tmp / nineteencells_sum ;
-	if(nineteennum > 1 &&  nineteencells_sum > 0) Y_Layer[LAYER][EVENT] = y_tmp / nineteencells_sum ;
+  float E1SumL_R = 0.;
+  float E7SumL_R = 0.;
+  float E19SumL_R = 0.;
+  float EAllSumL_R = 0.;
 
-	//	if(LAYER > 1) std::cout << " TROVATOOOOOOOOOOOOOOOOOOO " << seedEnergy  << std::endl;
+  float E1SumL_AbsW = 0.;
+  float E7SumL_AbsW = 0.;
+  float E19SumL_AbsW = 0.;
+  float EAllSumL_AbsW = 0.;
+
+  for(int iL=0; iL<MAXLAYERS; ++iL){
+    h_sum_layer[iL]->Fill(allcells_sum[iL]);
+    h_Seed_layer[iL]->Fill(seedEnergy[iL]);
+    h_layer_seven[iL]->Fill(sevencells_sum[iL]);
+    h_layer_nineteen[iL]->Fill(nineteencells_sum[iL]);
+
+    float layerE1 = seedEnergy[iL] * ( ADCtoMIP[iL] * weights2GeV * Weights_8L[iL] + 1.);
+    float layerE7 = sevencells_sum[iL] * ( ADCtoMIP[iL] * weights2GeV * Weights_8L[iL] + 1.);
+    float layerE19 = nineteencells_sum[iL] * ( ADCtoMIP[iL] * weights2GeV * Weights_8L[iL] + 1.);
+    float layerEAll = allcells_sum[iL] * ( ADCtoMIP[iL] * weights2GeV * Weights_8L[iL] + 1.);
+
+    h_sum_layer_AbsW[iL]->Fill(layerEAll);
+    h_Seed_layer_AbsW[iL]->Fill(layerE1);
+    h_layer_seven_AbsW[iL]->Fill(layerE7);
+    h_layer_nineteen_AbsW[iL]->Fill(layerE19);
+    
+    tp_E1_vs_layer->Fill(iL+1, seedEnergy[iL]);
+    tp_E7_vs_layer->Fill(iL+1, sevencells_sum[iL]);
+    tp_E19_vs_layer->Fill(iL+1, nineteencells_sum[iL]);
+
+    if(sevencells_sum[iL] != 0.){
+      h_E1oE7_layer[iL]->Fill(seedEnergy[iL]/sevencells_sum[iL]);
+      tp_E1oE7_vs_layer->Fill(iL+1, seedEnergy[iL]/sevencells_sum[iL]);
+    }
+    if(nineteencells_sum[iL] != 0){
+      h_E1oE19_layer[iL]->Fill(seedEnergy[iL]/nineteencells_sum[iL]);
+      h_E7oE19_layer[iL]->Fill(sevencells_sum[iL]/nineteencells_sum[iL]);
+      tp_E1oE19_vs_layer->Fill(iL, seedEnergy[iL]/nineteencells_sum[iL]);
+      tp_E7oE19_vs_layer->Fill(iL, sevencells_sum[iL]/nineteencells_sum[iL]);
+    }
+
+    h_x_layer[iL]->Fill(x_tmp[iL] / nineteencells_sum[iL]);
+    h_y_layer[iL]->Fill(y_tmp[iL] / nineteencells_sum[iL]);
+    h_x_y_layer[iL]->Fill(x_tmp[iL] / nineteencells_sum[iL], y_tmp[iL] / nineteencells_sum[iL]);
+
+    E1SumL_R += seedEnergy[iL];
+    E7SumL_R += sevencells_sum[iL];
+    E19SumL_R += nineteencells_sum[iL];
+    EAllSumL_R += allcells_sum[iL];
+
+    E1SumL_AbsW += layerE1;
+    E7SumL_AbsW += layerE7;
+    E19SumL_AbsW += layerE19;
+    EAllSumL_AbsW += layerEAll;
+  }
 
 
+  for(int iL=0; iL<MAXLAYERS; ++iL){
+    if(E1SumL_R != 0.){
+      tp_E1oSumL_vs_layer->Fill(iL, seedEnergy[iL]/E1SumL_R);
+      tp_E7oSumL_vs_layer->Fill(iL, sevencells_sum[iL]/E7SumL_R);
+      tp_E19oSumL_vs_layer->Fill(iL, nineteencells_sum[iL]/E19SumL_R);
+    }
+    h_sum_all->Fill(EAllSumL_R);
+    h_seven_all->Fill(E7SumL_R);
+    h_nineteen_all->Fill(E19SumL_R);
+
+    h_sum_all_AbsW->Fill(EAllSumL_AbsW);
+    h_seven_all_AbsW->Fill(E7SumL_AbsW);
+    h_nineteen_all_AbsW->Fill(E19SumL_AbsW);
+  }
+  
 }// analyze ends here
 
 
@@ -324,6 +462,7 @@ Layer_Sum_Analyzer::analyze(const edm::Event& event, const edm::EventSetup& setu
 void
 Layer_Sum_Analyzer::beginJob()
 {
+  std::cout << " Layer_Sum_Analyzer::beginJob " << std::endl;
 	HGCalCondObjectTextIO io(0);
 	edm::FileInPath fip(mapfile_);
 	if (!io.load(fip.fullPath(), essource_.emap_)) {
@@ -331,7 +470,7 @@ Layer_Sum_Analyzer::beginJob()
 	}
 
 	for(int iii = 0; iii < 16; iii++)
-		ADCtoMIP[iii] = ADCtoMIP[iii] / 1.3; // Converting response to 120 GeV protons to MIPs
+		ADCtoMIP[iii] = ADCtoMIP[iii] / MIP2ParticleCalib; // Converting response to 120 GeV protons to MIPs
 	/*
 	        for(int iii= 0; iii<16;iii++){
 	            LayerWeight[iii] += 0.8;
@@ -346,117 +485,8 @@ Layer_Sum_Analyzer::beginJob()
 void
 Layer_Sum_Analyzer::endJob()
 {
+  std::cout << " Layer_Sum_Analyzer::endJob " << std::endl;
 
-  //  std::cout << " >>> end job " << std::endl;
-	double allcells, sevencells, nineteencells;
-	bool doAllCells, do7Cells, do19Cells;
-	double E1SumL = 0.;
-	double E7SumL = 0.;
-	double E19SumL = 0.;
-
-	ofstream fs1;
-	fs1.open("./timeSynchro_HGCAL/HGC_CERN_Time_Synch.txt");
-	//	fs1 << "# " << "Event Num" << "\t" << "Time(us)" << "\t" << "Delta t(us)" << "\t" << "Cluster x[cm]" << "\t" << "Cluster y[cm]" << endl;
-	fs1 << "# " << "Event Num" << "\t" << "Delta t(us)" << "\t" << "Cluster x[cm]" << "\t" << "Cluster y[cm]" << endl;
-
-	//	std::cout << " (SPILL + 1) * EVENTSPERSPILL = " << (SPILL + 1) * EVENTSPERSPILL << " EVENTSPERSPILL = " << EVENTSPERSPILL << std::endl;
-	for(int event = 0; event < (SPILL + 1) * EVENTSPERSPILL; event++) {
-		allcells = sevencells = nineteencells = 0.;
-		doAllCells = do7Cells = do19Cells = true; // false;
-		//                fs1<<event+1<<"\t"<<200*Time_Stamp[event+1]/1000.<<"\t"<<200*Delta_Time_Stamp[event+1]/1000.<<endl;//division by 1000 to covert from ns --> us
-
-		E1SumL = 0.;
-		E7SumL = 0.;
-		E19SumL = 0.;
-
-
-		for(int layer = 0; layer < MAXLAYERS; layer++) {
-		  h_CM_layer[layer]->Fill(CMCells[layer][event]);
-
-		  allcells += AllCells[layer][event];
-		  sevencells += SevenCells[layer][event];
-		  nineteencells += NineteenCells[layer][event];
-
-		  E1SumL += SeedCells[layer][event];
-		  E7SumL += SevenCells[layer][event];
-		  E19SumL += NineteenCells[layer][event];
-
-		  h_Seed_layer[layer]->Fill(SeedCells[layer][event]);		  
-		  tp_E1_vs_layer->Fill(layer, SeedCells[layer][event]);
-		  tp_E7_vs_layer->Fill(layer, SevenCells[layer][event]);
-		  tp_E19_vs_layer->Fill(layer, NineteenCells[layer][event]);
-
-		  //	  if(layer > 1 ) std::cout << " SeedCells[layer][event] = " << SeedCells[layer][event] << std::endl;
-		  if(SevenCells[layer][event] != 0){
-		    h_E1oE7_layer[layer]->Fill(SeedCells[layer][event]/SevenCells[layer][event]);		  
-		    tp_E1oE7_vs_layer->Fill(layer, SeedCells[layer][event]/SevenCells[layer][event]);
-		  }
-		  if(NineteenCells[layer][event] != 0){
-		    h_E1oE19_layer[layer]->Fill(SeedCells[layer][event]/NineteenCells[layer][event]);		  
-		    h_E7oE19_layer[layer]->Fill(SevenCells[layer][event]/NineteenCells[layer][event]);
-		    tp_E1oE19_vs_layer->Fill(layer, SeedCells[layer][event]/NineteenCells[layer][event]);
-		    // std::cout << " layer = " << layer << " val = " << SeedCells[layer][event]/SevenCells[layer][event] 
-		    // 	      << " entries = " << tp_E1oE19_vs_layer->GetEntries() <<  std::endl;
-		    tp_E7oE19_vs_layer->Fill(layer, SevenCells[layer][event]/NineteenCells[layer][event]);		  
-		  }
-		  //		  fs1 << layer << "\t" << event + 1 << "\t" << 200 * Delta_Time_Stamp[event + 1] / 1000. << "\t" << X_Layer[layer][event] << "\t" << Y_Layer[layer][event] << endl;
-		  if(doAllCells) {
-		    h_sum_layer[layer]->Fill(AllCells[layer][event]);
-		  }
-		  if(do7Cells) {
-		    h_layer_seven[layer]->Fill(SevenCells[layer][event]);
-		  }
-		  if(do19Cells) {
-		    h_layer_nineteen[layer]->Fill(NineteenCells[layer][event]);
-		    h_x_layer[layer]->Fill(X_Layer[layer][event]);
-		    h_y_layer[layer]->Fill(Y_Layer[layer][event]);
-		    h_x_y_layer[layer]->Fill(X_Layer[layer][event], Y_Layer[layer][event]);
-		    cout << endl << "   " << layer << "     " << X_Layer[layer][event] << "     " << Y_Layer[layer][event] << endl;
-		    //fs1 << event + 1 << "\t" << 200 * Time_Stamp[event + 1] / 1000. << "\t" << 200 * Delta_Time_Stamp[event + 1] / 1000. << "\t" << X_Layer[layer][event] << "\t" << Y_Layer[layer][event] << endl;
-		    fs1 << event + 1 << "\t" << layer << "\t" << X_Layer[layer][event] << "\t" << Y_Layer[layer][event] << "\t" << Layer_Z[layer] << "\t" << endl;
-		  }
-		  
-		}
-
-		//		std::cout << " E1SumL = " << E1SumL << std::endl;
-		for(int layer = 0; layer < MAXLAYERS; layer++) {		
-		  if(E1SumL != 0.) tp_E1oSumL_vs_layer->Fill(layer, SeedCells[layer][event]/E1SumL);
-		  if(E7SumL != 0.) tp_E7oSumL_vs_layer->Fill(layer, SevenCells[layer][event]/E7SumL);
-		  if(E19SumL != 0.) tp_E19oSumL_vs_layer->Fill(layer, NineteenCells[layer][event]/E19SumL);
-		}
-
-		if(ELECTRONS || !PIONS) {
-		  if(allcells >= ALLCELLS_THRESHOLD) {
-		    h_sum_all->Fill(allcells);
-		    doAllCells = true;
-		  }
-		  if(sevencells >= SEVENCELLS_THRESHOLD) {
-		    h_seven_all->Fill(sevencells);
-		    do7Cells  = true;
-		  }
-		  if(nineteencells >= NINETEENCELLS_THRESHOLD) {
-		    h_nineteen_all->Fill(nineteencells / LayerSumWeight);
-		    do19Cells = true;
-		  }
-		}
-
-		if(PIONS) {
-			if(allcells <= ALLCELLS_THRESHOLD && allcells >= PION_ALLCELLS_THRESHOLD) {
-				h_sum_all->Fill(allcells);
-				doAllCells = true;
-			}
-			if(sevencells <= SEVENCELLS_THRESHOLD && allcells >= PION_7CELLS_THRESHOLD) {
-				h_seven_all->Fill(sevencells);
-				do7Cells  = true;
-			}
-			if(nineteencells <= NINETEENCELLS_THRESHOLD && allcells >= PION_19CELLS_THRESHOLD) {
-				h_nineteen_all->Fill(nineteencells / LayerSumWeight);
-				do19Cells = true;
-			}
-		}
-
-	}
-	fs1.close();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Reco/python/hgcaltbrechitplotter_cfi.py
+++ b/Reco/python/hgcaltbrechitplotter_cfi.py
@@ -33,5 +33,6 @@ FourLayerRecHitPlotterMax = cms.EDAnalyzer("FourLayerRecHitPlotterMax",
                               )
 
 LayerSumAnalyzer = cms.EDAnalyzer("Layer_Sum_Analyzer",
-               HGCALTBRECHITS = cms.InputTag("hgcaltbrechits","","unpack" )
+                                  HGCALTBRECHITS = cms.InputTag("hgcaltbrechits","","unpack" ),
+                                  CERN_8layers_config = cms.int32(1)
                               )

--- a/test_cfg_newEB.py
+++ b/test_cfg_newEB.py
@@ -1,0 +1,176 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+import os,sys
+
+options = VarParsing.VarParsing('standard') # avoid the options: maxEvents, files, secondaryFiles, output, secondaryOutput because they are already defined in 'standard'
+
+options.register('dataFolder',
+                 #'/afs/cern.ch/work/r/rchatter/Final_Event_Builder/CMSSW_8_0_1/src/HGCal/tmpOut/',
+                 #'/afs/cern.ch/user/a/amartell/public/HGCal/TB_data/'
+                 'tmpOut/',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 'folder containing raw text input')
+
+options.register('outputFolder',
+                 '/tmp/',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 'Result of processing')
+
+# options.register('commonPrefix',
+#                  '',
+#                  VarParsing.VarParsing.multiplicity.singleton,
+#                  VarParsing.VarParsing.varType.string,
+#                  'Input file to process')
+
+options.register('runNumber',
+                 850,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 'Input file to process')
+
+options.register('runType',
+                 'Unknown',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 'Type of run: HGCRun for run with beam on, PED for pedestal run, Unknown otherwise')
+
+options.register('chainSequence',
+                 0,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 '0: if runType is PED then do Digi, if runType is HGC_Run then do Digi and Reco (not implemented yet); 1: do Digi; 2: only Reco (not implemented yet); 3: Digi + highgain_correlation_cm; 4: event display sequence; 5: highgain_correlation_cm + event display sequence')
+
+options.register('nSpills',
+                 15,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 'Number of spills in run')
+
+options.register('pedestalsHighGain',
+                 'CondObjects/data/Ped_HighGain_L8.txt',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 'Path to high gain pedestals file')
+
+options.register('pedestalsLowGain',
+                 'CondObjects/data/Ped_LowGain_L8.txt',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 'Path to low gain pedestals file')
+
+options.register('configuration',
+                 1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 '1 if 8Layers with 5X0 sampling the center of the shower only; 2 if 8Layers with 25X0 sampling up to the tail of the shower')
+
+
+
+options.output = "test_output.root"
+options.maxEvents = -1
+
+options.parseArguments()
+
+# print options # <--- A better option is to call test_cfg is called with "print" argument e.g. cmsRun test_cfg.py print dataFolder=example1 outputFolder=example2 ...
+
+if not os.path.isdir(options.dataFolder):
+    sys.exit("Error: Data folder not found or inaccessible!")
+
+if not os.path.isdir(options.outputFolder):
+    os.system("mkdir -p " + options.outputFolder)
+
+if (options.runType != "PED" and options.runType != "HGCRun"):
+    sys.exit("Error: only runtypes PED and HGCRun supported for now; given runType was %s"%(options.runType))
+
+if (options.runType == "PED"):
+    if (os.path.isfile(options.pedestalsHighGain) or os.path.isfile(options.pedestalsLowGain)):
+        sys.exit("Error: Run %d is a pedestals run. The arguments pedestalsHighGain = %s and pedestalsLowGain = %s should be paths that do not lead to an existing file."%(options.runNumber, options.pedestalsHighGain, options.pedestalsLowGain))
+            
+
+
+################################
+process = cms.Process("unpack")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+####################################
+process.load('HGCal.StandardSequences.RawToDigi_cff')
+process.load('HGCal.StandardSequences.LocalReco_cff')
+process.load('HGCal.StandardSequences.dqm_cff')
+
+
+process.source = cms.Source("HGCalTBTextSource",
+                            run=cms.untracked.int32(options.runNumber), ### maybe this should be read from the file
+                            #fileNames=cms.untracked.vstring("file:Raw_data_New.txt") ### here a vector is provided, but in the .cc only the first one is used TO BE FIXED
+                            fileNames=cms.untracked.vstring("file:%s/%s_Output_%06d.txt"%(options.dataFolder,options.runType,options.runNumber)), ### here a vector is provided, but in the .cc only the first one is used TO BE FIXED
+                            nSpills=cms.untracked.uint32(options.nSpills),
+)
+
+
+
+######
+process.hgcaltbdigisplotter.pedestalsHighGain = cms.untracked.string(options.pedestalsHighGain)
+process.hgcaltbdigisplotter.pedestalsLowGain  = cms.untracked.string(options.pedestalsLowGain)
+
+process.hgcaltbrechits.pedestalLow = cms.string(options.pedestalsLowGain)
+process.hgcaltbrechits.pedestalHigh = cms.string(options.pedestalsHighGain)
+process.hgcaltbrechits.gainLow = cms.string('')
+process.hgcaltbrechits.gainHigh = cms.string('')
+
+process.dumpRaw = cms.EDAnalyzer("DumpFEDRawDataProduct",
+                              dumpPayload=cms.untracked.bool(True))
+
+process.dumpDigi = cms.EDAnalyzer("HGCalDigiDump")
+
+
+process.output = cms.OutputModule("PoolOutputModule",
+			fileName = cms.untracked.string(options.output)
+                                 )
+
+# process.TFileService = cms.Service("TFileService", fileName = cms.string("HGC_Output_6_Reco_Display.root") )
+if (options.chainSequence == 1):
+    process.TFileService = cms.Service("TFileService", fileName = cms.string("%s/%s_Output_%06d_Digi.root"%(options.outputFolder,options.runType,options.runNumber)))
+elif (options.chainSequence == 3 or options.chainSequence == 4 or options.chainSequence == 5 or options.chainSequence == 6):
+    process.TFileService = cms.Service("TFileService", fileName = cms.string("%s/%s_Output_%06d_Reco.root"%(options.outputFolder,options.runType,options.runNumber)))
+# process.TFileService = cms.Service("TFileService", fileName = cms.string("HGC_Output_6_Reco.root") )
+#process.TFileService = cms.Service("TFileService", fileName = cms.string("HGC_Output_6_Reco_Layer.root") )
+#process.TFileService = cms.Service("TFileService", fileName = cms.string("HGC_Output_6_Reco_Cluster.root") )
+
+
+
+if(options.configuration == "1"):
+    process.LayerSumAnalyzer.CERN_8layers_config = cms.int32(1)
+elif(options.configuration == "2"):
+    process.LayerSumAnalyzer.CERN_8layers_config = cms.int32(2)
+
+########Activate this to produce event displays#########################################
+#process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbrechitsplotter_highgain_new)
+
+################Not needed for DQM purposes, produces digi histograms for each channel, and the pedestal txt file needed for Digi->Reco
+#process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbdigisplotter)
+
+################Produces Reco histograms for each channel as well as a scatter plot of the Reco per channel#############
+#process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbrechitsplotter_highgain_correlation_cm)
+
+#################Produces Clusters of Recos(7cells, 19cells and all cells(full hexagons only))################
+#process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.LayerSumAnalyzer)
+
+################Miscellaneous##############################################################################
+#process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.FourLayerRecHitPlotterMax)
+
+if (options.chainSequence == 1):
+    process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbdigisplotter)
+elif (options.chainSequence == 3):
+    process.p =cms.Path(process.hgcaltbdigis)
+elif (options.chainSequence == 4):
+    process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbrechitsplotter_highgain_new)
+elif (options.chainSequence == 5):
+    process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbrechitsplotter_highgain_correlation_cm*process.hgcaltbrechitsplotter_highgain_new)
+elif (options.chainSequence == 6):
+    process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.LayerSumAnalyzer)
+
+process.end = cms.EndPath(process.output)


### PR DESCRIPTION
change Layer_Sum_Analyzer to deal with new event builder and support weights for energy estimate from absorber

test_cfg_newEB.py is updated to provide "configuration" option to choose between weights 

README is updated with basic instructions

FIXME: in Layer_Sum_Analyzer need to understand
- why only type 0 cells are considered for the analysis
- navigation from 1 to 7 to 19 cells
- radius variable used which seems meaningfull
