### PR TITLE
1st commit in arnaudWorking with HGCalTBClusterProducer; an example o…

### DIFF
--- a/CondObjects/src/HGCalElectronicsMap.cc
+++ b/CondObjects/src/HGCalElectronicsMap.cc
@@ -21,7 +21,7 @@ bool  HGCalElectronicsMap::MapEntry::operator<(const HGCalElectronicsMap::MapEnt
 bool HGCalElectronicsMap::existsDetId(DetId did) const
 {
 	DetIdMatch x(did.rawId());
-	return std::find_if(m_map.begin(), m_map.end(), x) == m_map.end();
+	return std::find_if(m_map.begin(), m_map.end(), x) != m_map.end();
 }
 
 bool HGCalElectronicsMap::existsEId(uint32_t eid) const

--- a/DataFormats/interface/HGCalTBCluster.h
+++ b/DataFormats/interface/HGCalTBCluster.h
@@ -1,0 +1,40 @@
+#ifndef DATAFORMATS_HGCALTBCLUSTER_H
+#define DATAFORMATS_HGCALTBCLUSTER_H 1
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+
+/** \class HGCalTBCluster
+ *
+ * \author Arnaud Steen
+ * 2D hgcal cluster class
+ */
+
+namespace reco{
+
+  class HGCalTBCluster : public reco::CaloCluster
+    {
+    public:
+      HGCalTBCluster();
+      HGCalTBCluster(int layer, float energy, float energyLow, float energyHigh );
+	
+      int   layer() const { return _layer; }
+      float energyLow() const {	return _energyLow; }
+      float energyHigh() const { return _energyHigh; }
+      float recHitEnergyHigh( int i) const{ return hitsAndFractions_.at(i).second*_energyHigh; }
+      float recHitEnergyLow( int i) const{ return hitsAndFractions_.at(i).second*_energyLow; }
+
+      void setLayer(int val){ _layer=val; }
+      void setEnergyLow(float val){ _energyLow=val; }
+      void setEnergyHigh(float val){ _energyHigh=val; }
+      
+      
+    protected : 
+      int _layer;
+      float _energyLow;
+      float _energyHigh;
+    };
+
+  std::ostream& operator<<(std::ostream& s, const HGCalTBCluster& cluster);
+}
+
+#endif

--- a/DataFormats/interface/HGCalTBClusterCollection.h
+++ b/DataFormats/interface/HGCalTBClusterCollection.h
@@ -1,0 +1,18 @@
+#ifndef DATAFORMATS_HGCCLUSTER_HGCCLUSTERCOLLECTION_H
+#define DATAFORMATS_HGCCLUSTER_HGCCLUSTERCOLLECTION_H
+
+#include "DataFormats/Common/interface/EDCollection.h"
+#include "HGCal/DataFormats/interface/HGCalTBCluster.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+// ~ copy paste from "HGCal/DataFormats/interface/HGCalTBRecHitCollection.h"
+
+namespace reco
+{
+  typedef edm::EDCollection<HGCalTBCluster> HGCalTBClusterCollection;
+  typedef edm::Ref<HGCalTBClusterCollection> HGCalTBClusterRef;
+  typedef edm::RefVector<HGCalTBClusterCollection> HGCalTBClusterRefs;
+  typedef edm::RefProd<HGCalTBClusterCollection> HGCalTBClustersRef;
+}
+#endif

--- a/DataFormats/src/HGCalTBCluster.cc
+++ b/DataFormats/src/HGCalTBCluster.cc
@@ -1,0 +1,41 @@
+#include "HGCal/DataFormats/interface/HGCalTBCluster.h"
+//#include "DataFormats/Math/interface/Point3D.h"
+#include <iostream>
+namespace reco
+{
+
+  HGCalTBCluster::HGCalTBCluster() : reco::CaloCluster()
+  {
+
+  }
+
+  HGCalTBCluster::HGCalTBCluster(int layer, float energy, float energyLow, float energyHigh) :
+    reco::CaloCluster(),
+    _layer(layer),
+    _energyLow(energyLow),
+    _energyHigh(energyHigh)
+  {
+		this->setEnergy(energy);
+  }
+
+  std::ostream& operator<<(std::ostream& out, const HGCalTBCluster& cluster)
+  {
+ 
+    if(!out) return out;
+
+    out<<"CaloCluster , algoID="<<cluster.algoID()
+       <<", Layer="<<cluster.layer()    
+       <<", Ehigh="<<cluster.energyHigh()
+       <<", Elow="<<cluster.energyLow();
+      //<<", Position="<<cluster.position().x()<<","<<cluster.position().y()<<","<<cluster.position().z();
+    if( cluster.correctedEnergy() != -1.0 ) {
+      out << ", E_corr="<<cluster.correctedEnergy();
+    }
+    out<<", nhits="<<cluster.hitsAndFractions().size()<<std::endl;
+    for(unsigned i=0; i<cluster.hitsAndFractions().size(); i++ ) {
+      out<<""<<cluster.printHitAndFraction(i)<<", ";
+    }
+    return out;
+  }
+
+}

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -1,5 +1,7 @@
 #include "HGCal/DataFormats/interface/HGCalTBRecHit.h"
 #include "HGCal/DataFormats/interface/HGCalTBRecHitCollections.h"
+#include "HGCal/DataFormats/interface/HGCalTBCluster.h"
+#include "HGCal/DataFormats/interface/HGCalTBClusterCollection.h"
 #include "HGCal/DataFormats/interface/HGCalTBDataFrameContainers.h"
 #include "HGCal/DataFormats/interface/HGCalTBTrackCollection.h"
 
@@ -16,7 +18,10 @@ struct dictionary {
 	std::vector<HGCalTBRecHit> _HGCTBRHitVect;
 //	edm::SortedCollection<HGCalTBRecHit> _theHGCTBRsc;
 //	edm::Wrapper< HGCalTBRecHitCollection > _HGCTBeeRHitProd;
-
+	
+	reco::HGCalTBCluster _aCluster;
+	std::vector<reco::HGCalTBCluster> _HGCTBClusterVect;
+	
 	SKIROC2DigiCollection _SR2DC;
 	edm::Wrapper<SKIROC2DigiCollection> _theSR2DC;
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -16,4 +16,8 @@
   
 
   <class name="edm::reftobase::Holder<CaloRecHit, edm::Ref<edm::SortedCollection<HGCalTBRecHit, edm::StrictWeakOrdering<HGCalTBRecHit> >, HGCalTBRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HGCalTBRecHit, edm::StrictWeakOrdering<HGCalTBRecHit> >, HGCalTBRecHit> > >" />
+  <class name="reco::HGCalTBCluster"/>
+  <class name="reco::HGCalTBClusterCollection"/>
+  <class name="edm::Wrapper<edm::EDCollection<reco::HGCalTBCluster> >"/>
+
 </lcgdict>

--- a/Geometry/BuildFile.xml
+++ b/Geometry/BuildFile.xml
@@ -2,4 +2,5 @@
    <lib name="1"/>
 </export>
 <use name="HGCal/DataFormats"/>
+<use name="HGCal/CondObjects"/>
 

--- a/Geometry/interface/HGCalTBTopology.h
+++ b/Geometry/interface/HGCalTBTopology.h
@@ -1,6 +1,7 @@
 #ifndef HGCAL_GEOMETRY_HGCALTBTOPOLOGY_H
 #define HGCAL_GEOMETRY_HGCALTBTOPOLOGY_H 1
 
+#include "HGCal/CondObjects/interface/HGCalElectronicsMap.h"
 #include "HGCal/DataFormats/interface/HGCalTBDetId.h"
 #include "set"
 /** \class HGCalTBTopology
@@ -17,8 +18,7 @@ public:
 	// valid sensorSizes are 128 and 256
 	bool iu_iv_valid(int layer, int sensor_iu, int sensor_iv, int iu, int iv, int sensorSize) const;
 	double Cell_Area(int cell_type) const;//returns area in cm*cm
-	std::set<HGCalTBDetId> getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, bool reverseLayer=false) const;
-	int getCellType( int u, int v, int sensorSize, bool reverseLayer=false) const;
+	std::set<HGCalTBDetId> getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, const HGCalElectronicsMap &) const;
 };
 
 #endif

--- a/Geometry/interface/HGCalTBTopology.h
+++ b/Geometry/interface/HGCalTBTopology.h
@@ -1,6 +1,8 @@
 #ifndef HGCAL_GEOMETRY_HGCALTBTOPOLOGY_H
 #define HGCAL_GEOMETRY_HGCALTBTOPOLOGY_H 1
 
+#include "HGCal/DataFormats/interface/HGCalTBDetId.h"
+#include "set"
 /** \class HGCalTBTopology
   *
   * Reference: https://indico.cern.ch/event/456955/
@@ -15,6 +17,8 @@ public:
 	// valid sensorSizes are 128 and 256
 	bool iu_iv_valid(int layer, int sensor_iu, int sensor_iv, int iu, int iv, int sensorSize) const;
 	double Cell_Area(int cell_type) const;//returns area in cm*cm
+	std::set<HGCalTBDetId> getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, bool reverseLayer=false) const;
+	int getCellType( int u, int v, int sensorSize, bool reverseLayer=false) const;
 };
 
 #endif

--- a/Geometry/src/HGCalTBTopology.cc
+++ b/Geometry/src/HGCalTBTopology.cc
@@ -46,31 +46,7 @@ double HGCalTBTopology::Cell_Area(int cell_type) const
 	else return -1.; //signifies an invalid cell type
 }
 
-int HGCalTBTopology::getCellType( int iu, int iv, int sensorSize, bool reversedLayer ) const
-{
-  int aiu=abs(iu);
-  int aiv=abs(iv);
-  int asum=abs(iu+iv);
-  if( sensorSize==128 ){
-    if( ((iu==2 && iv == -4) || (iu==-1 && iv == 2)) && reversedLayer==false )
-      return 4;//calib pad
-    else if( ((iu==-2 && iv == 4) || (iu==1 && iv == -2)) && reversedLayer==true)
-      return 4;//calib pad
-
-    else if( (aiu+aiv>=6) && (aiu==1||aiu>=5) && (aiv==1||aiv>=5) && (asum==1||asum>=5) )
-      return 2;//half hex
-    else if( (iu==-3&&iv==-4) || (iu==-7&&iv==4) || (iu==4&&iv==3) || (iu==7&&iv==-3) || 
-	     (iu==-4&&iv==-3) || (iu==-7&&iv==3) || (iu==3&&iv==4) || (iu==7&&iv==-4) ) //no hit should be found in these anyway
-      return 3;//mouse bite
-    else if( (iu==2&&iv==-6) || (iu==-4&&iv==7) || (iu==-3&&iv==7) || (iu==4&&iv==-6) ||
-	     (iu==3&&iv==-7) || (iu==-4&&iv==6) || (iu==-2&&iv==6) || (iu==4&&iv==-7) ) //no hit should be found in these anyway
-      return 5; //merged cell
-    else return 0;
-  }
-  else return -1;
-}
-
-std::set<HGCalTBDetId> HGCalTBTopology::getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, bool reversedLayer) const
+std::set<HGCalTBDetId> HGCalTBTopology::getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, const HGCalElectronicsMap& emap) const
 {
 	int layer=detid.layer();
 	std::set<HGCalTBDetId> detids;
@@ -81,15 +57,18 @@ std::set<HGCalTBDetId> HGCalTBTopology::getNeighboringCellsDetID(HGCalTBDetId de
 			int iV=detid.sensorIV();
 			int iu=detid.iu()+u;
 			int iv=detid.iv()+v;
-			bool validCoord = iu_iv_valid( layer, iU, iV, iu, iv, sensorSize);
-			if( !validCoord ) continue;
-			int cellType=getCellType( iu, iv, sensorSize, reversedLayer);
-			HGCalTBDetId did( layer, iU, iV, iu, iv, cellType);
-			detids.insert(did);
-			if( cellType==4 ){// 4 is outer calib pad; need also to include inner calib pad
-				cellType=1;
-				HGCalTBDetId didbis( layer, iU, iV, iu, iv, cellType);
-				detids.insert(didbis);
+			if( iu_iv_valid( layer, iU, iV, iu, iv, sensorSize)!=true )
+				continue;
+			for(unsigned int cellType=0; cellType<6; cellType++){
+				HGCalTBDetId did( layer, iU, iV, iu, iv, cellType );
+				if( emap.existsDetId(did)==true ){
+					detids.insert(did);
+					if( cellType==1 ){
+						HGCalTBDetId didbis( layer, iU, iV, iu, iv, 4);
+						detids.insert(didbis);
+					}
+					break;
+				}
 			}
 		}
 	}

--- a/Geometry/src/HGCalTBTopology.cc
+++ b/Geometry/src/HGCalTBTopology.cc
@@ -2,6 +2,7 @@
 #include "HGCal/Geometry/interface/HGCalTBCellParameters.h"
 #include "math.h"
 #include <stdlib.h>
+#include <iostream>
 #define PI 3.14159265
 
 bool HGCalTBTopology::iu_iv_valid(int layer, int sensor_iu, int sensor_iv, int iu, int iv, int sensorSize) const
@@ -45,3 +46,52 @@ double HGCalTBTopology::Cell_Area(int cell_type) const
 	else return -1.; //signifies an invalid cell type
 }
 
+int HGCalTBTopology::getCellType( int iu, int iv, int sensorSize, bool reversedLayer ) const
+{
+  int aiu=abs(iu);
+  int aiv=abs(iv);
+  int asum=abs(iu+iv);
+  if( sensorSize==128 ){
+    if( ((iu==2 && iv == -4) || (iu==-1 && iv == 2)) && reversedLayer==false )
+      return 4;//calib pad
+    else if( ((iu==-2 && iv == 4) || (iu==1 && iv == -2)) && reversedLayer==true)
+      return 4;//calib pad
+
+    else if( (aiu+aiv>=6) && (aiu==1||aiu>=5) && (aiv==1||aiv>=5) && (asum==1||asum>=5) )
+      return 2;//half hex
+    else if( (iu==-3&&iv==-4) || (iu==-7&&iv==4) || (iu==4&&iv==3) || (iu==7&&iv==-3) || 
+	     (iu==-4&&iv==-3) || (iu==-7&&iv==3) || (iu==3&&iv==4) || (iu==7&&iv==-4) ) //no hit should be found in these anyway
+      return 3;//mouse bite
+    else if( (iu==2&&iv==-6) || (iu==-4&&iv==7) || (iu==-3&&iv==7) || (iu==4&&iv==-6) ||
+	     (iu==3&&iv==-7) || (iu==-4&&iv==6) || (iu==-2&&iv==6) || (iu==4&&iv==-7) ) //no hit should be found in these anyway
+      return 5; //merged cell
+    else return 0;
+  }
+  else return -1;
+}
+
+std::set<HGCalTBDetId> HGCalTBTopology::getNeighboringCellsDetID(HGCalTBDetId detid, int sensorSize, int maxDistance, bool reversedLayer) const
+{
+	int layer=detid.layer();
+	std::set<HGCalTBDetId> detids;
+	for(int u=-maxDistance; u<=maxDistance; u++){
+		for(int v=-maxDistance; v<=maxDistance; v++){
+			if( (u==0 && v==0) || abs(u+v)>maxDistance ) continue;
+			int iU=detid.sensorIU();
+			int iV=detid.sensorIV();
+			int iu=detid.iu()+u;
+			int iv=detid.iv()+v;
+			bool validCoord = iu_iv_valid( layer, iU, iV, iu, iv, sensorSize);
+			if( !validCoord ) continue;
+			int cellType=getCellType( iu, iv, sensorSize, reversedLayer);
+			HGCalTBDetId did( layer, iU, iV, iu, iv, cellType);
+			detids.insert(did);
+			if( cellType==4 ){// 4 is outer calib pad; need also to include inner calib pad
+				cellType=1;
+				HGCalTBDetId didbis( layer, iU, iV, iu, iv, cellType);
+				detids.insert(didbis);
+			}
+		}
+	}
+	return detids;
+}

--- a/Reco/plugins/EventDisplay.cc
+++ b/Reco/plugins/EventDisplay.cc
@@ -1,0 +1,249 @@
+#include <memory>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <iterator>
+#include "TH2Poly.h"
+#include "TProfile.h"
+#include "TH1F.h"
+#include "TH2F.h"
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Math/interface/Error.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/Math/interface/Point3D.h"
+
+#include "HGCal/DataFormats/interface/HGCalTBDetId.h"
+#include "HGCal/DataFormats/interface/HGCalTBClusterCollection.h"
+#include "HGCal/DataFormats/interface/HGCalTBElectronicsId.h"
+
+#include "HGCal/Geometry/interface/HGCalTBCellVertices.h"
+#include "HGCal/Geometry/interface/HGCalTBTopology.h"
+#include "HGCal/Geometry/interface/HGCalTBGeometryParameters.h"
+#include "HGCal/Geometry/interface/HGCalTBSpillParameters.h"
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "HGCal/CondObjects/interface/HGCalElectronicsMap.h"
+#include "HGCal/CondObjects/interface/HGCalCondObjectTextIO.h"
+
+#define MAXVERTICES 6
+static const double delta = 0.00001;//Add/subtract delta = 0.00001 to x,y of a cell centre so the TH2Poly::Fill doesnt have a problem at the edges where the centre of a half-hex cell passes through the sennsor boundary line.
+
+using namespace std;
+
+class EventDisplay : public edm::one::EDAnalyzer<edm::one::SharedResources>
+{
+
+public:
+  explicit EventDisplay(const edm::ParameterSet&);
+  ~EventDisplay();
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginJob() override;
+  void analyze(const edm::Event& , const edm::EventSetup&) override;
+  virtual void endJob() override;
+  void InitTH2Poly(TH2Poly& poly, int layerID, int sensorIU, int sensorIV);
+
+  // ----------member data ---------------------------
+  //  edm::EDGetToken HGCalTBRecHitCollection_;
+  edm::EDGetToken HGCalTBClusterCollection_;
+  edm::EDGetToken HGCalTBClusterCollection7_;
+  edm::EDGetToken HGCalTBClusterCollection19_;
+  std::string mapfile_ = "HGCal/CondObjects/data/map_CERN_8Layers_Sept2016.txt";
+  struct {
+    HGCalElectronicsMap emap_;
+  } essource_;
+  int nlayers;
+  int sensorsize;
+  int _evtID;
+  HGCalTBTopology IsCellValid;
+  HGCalTBCellVertices TheCell;
+  std::vector<std::pair<double, double>> CellXY;
+  std::pair<double, double> CellCentreXY;
+  edm::Service<TFileService> fs;
+};
+
+EventDisplay::EventDisplay(const edm::ParameterSet& iConfig) :
+  nlayers( iConfig.getUntrackedParameter<int>("Nlayers",8) ),
+  sensorsize( iConfig.getUntrackedParameter<int>("SensorSize",128) )
+{
+  usesResource("TFileService");
+  HGCalTBClusterCollection_ = consumes<reco::HGCalTBClusterCollection>(iConfig.getParameter<edm::InputTag>("HGCALTBCLUSTERS"));
+  HGCalTBClusterCollection7_ = consumes<reco::HGCalTBClusterCollection>(iConfig.getParameter<edm::InputTag>("HGCALTBCLUSTERS7"));
+  HGCalTBClusterCollection19_ = consumes<reco::HGCalTBClusterCollection>(iConfig.getParameter<edm::InputTag>("HGCALTBCLUSTERS19"));
+  _evtID = 0;
+}
+
+
+EventDisplay::~EventDisplay()
+{
+}
+
+void EventDisplay::InitTH2Poly(TH2Poly& poly, int layerID, int sensorIU, int sensorIV)
+{
+  double HexX[MAXVERTICES] = {0.};
+  double HexY[MAXVERTICES] = {0.};
+
+  for(int iv = -7; iv < 8; iv++) {
+    for(int iu = -7; iu < 8; iu++) {
+      if(!IsCellValid.iu_iv_valid(layerID, sensorIU, sensorIV, iu, iv, sensorsize)) continue;
+      CellXY = TheCell.GetCellCoordinatesForPlots(layerID, sensorIU, sensorIV, iu, iv, sensorsize);
+      assert(CellXY.size() == 4 || CellXY.size() == 6);
+      unsigned int iVertex = 0;
+      for(std::vector<std::pair<double, double>>::const_iterator it = CellXY.begin(); it != CellXY.end(); it++) {
+	HexX[iVertex] =  it->first;
+	HexY[iVertex] =  it->second;
+	++iVertex;
+      }
+      //Somehow cloning of the TH2Poly was not working. Need to look at it. Currently physically booked another one.
+      poly.AddBin(CellXY.size(), HexX, HexY);
+    }//loop over iu
+  }//loop over iv
+}
+//
+
+// ------------ method called for each event  ------------
+void
+EventDisplay::analyze(const edm::Event& event, const edm::EventSetup& setup)
+{
+
+  edm::Handle<reco::HGCalTBClusterCollection> clusters;
+  event.getByToken(HGCalTBClusterCollection_, clusters);
+  edm::Handle<reco::HGCalTBClusterCollection> clusters7;
+  event.getByToken(HGCalTBClusterCollection7_, clusters7);
+  edm::Handle<reco::HGCalTBClusterCollection> clusters19;
+  event.getByToken(HGCalTBClusterCollection19_, clusters19);
+
+  std::ostringstream os( std::ostringstream::ate );
+  TH2Poly *h_RecHit_layer[nlayers];
+  TH2Poly *h_Cluster_layer[nlayers];
+  TH2Poly *h_Cluster7_layer[nlayers];
+  TH2Poly *h_Cluster19_layer[nlayers];
+  for( int ilayer=0; ilayer<nlayers; ilayer++ ){
+    os.str("");
+    os << "Layer" << ilayer << "_Event" << _evtID;
+    h_RecHit_layer[ilayer] = fs->make<TH2Poly>();
+    h_RecHit_layer[ilayer]->SetName( os.str().c_str() );
+    h_RecHit_layer[ilayer]->SetTitle( os.str().c_str() );
+    InitTH2Poly(*h_RecHit_layer[ilayer],ilayer,0,0);
+    os.str("");
+    os << "Layer" << ilayer << "_Event" << _evtID << "_cluster";
+    h_Cluster_layer[ilayer] = fs->make<TH2Poly>();
+    h_Cluster_layer[ilayer]->SetName( os.str().c_str() );
+    h_Cluster_layer[ilayer]->SetTitle( os.str().c_str() );
+    InitTH2Poly(*h_Cluster_layer[ilayer],ilayer,0,0);
+    os.str("");
+    os << "Layer" << ilayer << "_Event" << _evtID << "_cluster7";
+    h_Cluster7_layer[ilayer] = fs->make<TH2Poly>();
+    h_Cluster7_layer[ilayer]->SetName( os.str().c_str() );
+    h_Cluster7_layer[ilayer]->SetTitle( os.str().c_str() );
+    InitTH2Poly(*h_Cluster7_layer[ilayer],ilayer,0,0);
+    os.str("");
+    os << "Layer" << ilayer << "_Event" << _evtID << "_cluster19";
+    h_Cluster19_layer[ilayer] = fs->make<TH2Poly>();
+    h_Cluster19_layer[ilayer]->SetName( os.str().c_str() );
+    h_Cluster19_layer[ilayer]->SetTitle( os.str().c_str() );
+    InitTH2Poly(*h_Cluster19_layer[ilayer],ilayer,0,0);
+
+  }
+  _evtID++;
+  
+  float clusterID[nlayers];
+  for(int i=0; i<nlayers; i++) 
+    clusterID[i]=0.;
+
+  for( auto cluster : *clusters ){
+    clusterID[ cluster.layer()-1 ]+=1.0;
+    for( std::vector< std::pair<DetId,float> >::const_iterator it=cluster.hitsAndFractions().begin(); it!=cluster.hitsAndFractions().end(); ++it ){
+      HGCalTBDetId detID=(*it).first;
+      if(!IsCellValid.iu_iv_valid( detID.layer(),
+				   detID.sensorIU(), detID.sensorIV(), 
+				   detID.iu(), detID.iv(), sensorsize ) 
+	 )  continue;
+      CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots( detID.layer(), 
+							       detID.sensorIU(), detID.sensorIV(), 
+							       detID.iu(), detID.iv(), sensorsize );
+      double iux = (CellCentreXY.first < 0 ) ? (CellCentreXY.first + delta) : (CellCentreXY.first - delta) ;
+      double iuy = (CellCentreXY.second < 0 ) ? (CellCentreXY.second + delta) : (CellCentreXY.second - delta);
+      if( detID.cellType()!=1 )
+	h_Cluster_layer[ detID.layer()-1 ]->Fill(iux , iuy, clusterID[ detID.layer()-1 ]);
+      h_RecHit_layer[ detID.layer()-1 ]->Fill(iux , iuy, (*it).second*cluster.energy());
+    }
+  }
+
+  for(int i=0; i<nlayers; i++) 
+    clusterID[i]=0.;
+  for( auto cluster : *clusters7 ){
+    clusterID[ cluster.layer()-1 ]+=1.0;
+    for( std::vector< std::pair<DetId,float> >::const_iterator it=cluster.hitsAndFractions().begin(); it!=cluster.hitsAndFractions().end(); ++it ){
+      HGCalTBDetId detID=(*it).first;
+      if(!IsCellValid.iu_iv_valid( detID.layer(),
+  				   detID.sensorIU(), detID.sensorIV(), 
+  				   detID.iu(), detID.iv(), sensorsize ) 
+  	 )  continue;
+      CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots( detID.layer(), 
+  							       detID.sensorIU(), detID.sensorIV(), 
+  							       detID.iu(), detID.iv(), sensorsize );
+      double iux = (CellCentreXY.first < 0 ) ? (CellCentreXY.first + delta) : (CellCentreXY.first - delta) ;
+      double iuy = (CellCentreXY.second < 0 ) ? (CellCentreXY.second + delta) : (CellCentreXY.second - delta);
+      if( detID.cellType()!=1 )
+	h_Cluster7_layer[ detID.layer()-1 ]->Fill(iux , iuy, clusterID[ detID.layer()-1 ]);
+    }
+  }
+  
+  for(int i=0; i<nlayers; i++) 
+    clusterID[i]=0.;
+  for( auto cluster : *clusters19 ){
+    clusterID[ cluster.layer()-1 ]+=1.0;
+    for( std::vector< std::pair<DetId,float> >::const_iterator it=cluster.hitsAndFractions().begin(); it!=cluster.hitsAndFractions().end(); ++it ){
+      HGCalTBDetId detID=(*it).first;
+      if(!IsCellValid.iu_iv_valid( detID.layer(),
+  				   detID.sensorIU(), detID.sensorIV(), 
+  				   detID.iu(), detID.iv(), sensorsize ) 
+  	 )  continue;
+      CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots( detID.layer(), 
+  							       detID.sensorIU(), detID.sensorIV(), 
+  							       detID.iu(), detID.iv(), sensorsize );
+      double iux = (CellCentreXY.first < 0 ) ? (CellCentreXY.first + delta) : (CellCentreXY.first - delta) ;
+      double iuy = (CellCentreXY.second < 0 ) ? (CellCentreXY.second + delta) : (CellCentreXY.second - delta);
+      if( detID.cellType()!=1 )
+	h_Cluster19_layer[ detID.layer()-1 ]->Fill(iux , iuy, clusterID[ detID.layer()-1 ]);
+    }
+  }
+
+}
+
+void
+EventDisplay::beginJob()
+{
+  HGCalCondObjectTextIO io(0);
+  edm::FileInPath fip(mapfile_);
+  if (!io.load(fip.fullPath(), essource_.emap_)) {
+    throw cms::Exception("Unable to load electronics map");
+  }
+}
+
+void
+EventDisplay::endJob()
+{
+
+}
+
+void
+EventDisplay::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EventDisplay);

--- a/Reco/plugins/HGCalTBClusterProducer.cc
+++ b/Reco/plugins/HGCalTBClusterProducer.cc
@@ -1,0 +1,207 @@
+#include "HGCal/Reco/plugins/HGCalTBClusterProducer.h"
+#include "HGCal/Geometry/interface/HGCalTBTopology.h"
+#include "HGCal/Geometry/interface/HGCalTBCellVertices.h"
+
+#include <map>
+#include <algorithm>
+#include <sstream>
+
+HGCalTBClusterProducer::HGCalTBClusterProducer(const edm::ParameterSet& cfg) : 
+  _outputCollectionName(cfg.getParameter<std::string>("OutputCollectionName")),
+  _rechitToken(consumes<HGCalTBRecHitCollection>(cfg.getParameter<edm::InputTag>("rechitCollection"))),
+  _runDynamicCluster(cfg.getUntrackedParameter<bool>("runDynamicCluster",true)),
+  _runCluster7(cfg.getUntrackedParameter<bool>("runCluster7",true)),
+  _runCluster19(cfg.getUntrackedParameter<bool>("runCluster19",true)),
+  _sensorSize(cfg.getUntrackedParameter<int>("sensorSize",128)),
+  _minEnergy(cfg.getUntrackedParameter<double>("minEnergy",0.0))
+{
+  float sum=0.;
+  std::vector<double> vec;
+  sum+=0.0 ; vec.push_back( sum );
+  sum+=5.35; vec.push_back( sum );
+  sum+=5.17; vec.push_back( sum );
+  sum+=3.92; vec.push_back( sum );
+  sum+=4.08; vec.push_back( sum );
+  sum+=1.15; vec.push_back( sum );
+  sum+=4.11; vec.push_back( sum );
+  sum+=2.14; vec.push_back( sum );
+  //cern config 1 (5X0->15X0) is default
+  _layerZPositions = cfg.getUntrackedParameter< std::vector<double> >("LayerZPositions",vec);
+
+  std::vector<int> vb; 
+  for(unsigned int i=0; i<_layerZPositions.size(); i++)
+    if( i%2 == 0 ) vb.push_back(i);
+  _reversedLayers = cfg.getUntrackedParameter< std::vector<int> >("reversedLayers",vb);
+  //by default even layers are reversed (for 8 layers cern config: layers 5 and 7 are reversed)
+
+  produces <reco::HGCalTBClusterCollection>(_outputCollectionName);
+  if( _runCluster7 ){
+    std::ostringstream os( std::ostringstream::ate );
+    os.str("");os << _outputCollectionName << 7;
+    _outputCollectionName7=os.str();
+    produces <reco::HGCalTBClusterCollection>(_outputCollectionName7);
+  }
+  if( _runCluster19 ){
+    std::ostringstream os( std::ostringstream::ate );
+    os.str("");os << _outputCollectionName << 19;
+    _outputCollectionName19=os.str();
+    produces <reco::HGCalTBClusterCollection>(_outputCollectionName19);
+  }
+}
+
+void HGCalTBClusterProducer::produce(edm::Event& event, const edm::EventSetup& iSetup)
+{
+
+  std::auto_ptr<reco::HGCalTBClusterCollection> clusters(new reco::HGCalTBClusterCollection);
+  std::auto_ptr<reco::HGCalTBClusterCollection> clusters7(new reco::HGCalTBClusterCollection);
+  std::auto_ptr<reco::HGCalTBClusterCollection> clusters19(new reco::HGCalTBClusterCollection);
+
+  edm::Handle<HGCalTBRecHitCollection> rechits;
+  event.getByToken(_rechitToken, rechits);
+  std::map<int, HGCalTBRecHitCollection> hitmap;
+
+  for(auto hit : *rechits ){
+    if( hitmap.find( hit.id().layer() )!=hitmap.end() && hit.energy()>_minEnergy )
+      hitmap[ hit.id().layer() ].push_back(hit);
+    else{
+      HGCalTBRecHitCollection hitcol;
+      hitcol.push_back(hit);
+      std::pair< int, HGCalTBRecHitCollection > p( hit.id().layer(),hitcol );
+      hitmap.insert(p);
+    }
+  }
+  for( std::map<int,HGCalTBRecHitCollection>::iterator it=hitmap.begin(); it!=hitmap.end(); ++it ){
+    if( _runDynamicCluster ){
+      std::vector<reco::HGCalTBCluster> vec;
+      createDynamicClusters(it->second, vec);
+      for( std::vector<reco::HGCalTBCluster>::iterator jt=vec.begin(); jt!=vec.end(); ++jt )
+	clusters->push_back(*jt);
+    }
+    if( _runCluster7 ){
+      reco::HGCalTBCluster cluster;
+      createSeededClusters(it->second,cluster,1);
+      clusters7->push_back(cluster);
+    }
+    if( _runCluster19 ){
+      reco::HGCalTBCluster cluster;
+      createSeededClusters(it->second,cluster,2);
+      clusters19->push_back(cluster);
+    }
+  }
+  // std::cout << "number of clusters = " << clusters->size() << std::endl;
+  // std::cout << "number of clusters7 = " << clusters7->size() << std::endl;
+  // std::cout << "number of clusters19 = " << clusters19->size() << std::endl;
+  if( _runDynamicCluster )
+    event.put(clusters, _outputCollectionName);
+  if( _runCluster7 )
+    event.put(clusters7, _outputCollectionName7);
+  if( _runCluster19 )
+    event.put(clusters19, _outputCollectionName19);
+}
+
+void HGCalTBClusterProducer::createDynamicClusters(HGCalTBRecHitCollection rechits, std::vector<reco::HGCalTBCluster> &clusterCol)
+{
+  _maxTransverse=1;
+  HGCalTBCellVertices cellVertice;
+  std::pair<double, double> CellCentreXY;
+  std::vector<HGCalTBDetId> temp;
+  for( std::vector<HGCalTBRecHit>::iterator it=rechits.begin(); it!=rechits.end(); ++it){
+    if( std::find( temp.begin(),temp.end(),(*it).id() )!=temp.end() ) continue;
+    temp.push_back( (*it).id() );
+    std::vector<HGCalTBDetId> clusterDetIDs;
+    clusterDetIDs.push_back( (*it).id() );
+    buildCluster(rechits, temp, clusterDetIDs);            
+    reco::HGCalTBCluster cluster;
+    cluster.setLayer( (*it).id().layer() );
+    float energyHigh=0.;
+    float energyLow=0.;
+    float energy=0.;
+    float x,y,z; 
+    x = y = z = 0.0;
+    for( std::vector<HGCalTBDetId>::iterator jt=clusterDetIDs.begin(); jt!=clusterDetIDs.end(); ++jt){
+      HGCalTBRecHit hit=(*rechits.find(*jt));
+      energyHigh+=hit.energyHigh();
+      energyLow+=hit.energyLow();
+      energy+=hit.energy();
+      CellCentreXY=cellVertice.GetCellCentreCoordinatesForPlots( (*jt).layer(), (*jt).sensorIU(), (*jt).sensorIV(), (*jt).iu(), (*jt).iv(), _sensorSize);
+      x += CellCentreXY.first*hit.energy();
+      y += CellCentreXY.second*hit.energy();
+      z += _layerZPositions.at( (*jt).layer()-1 )*hit.energy();
+    } 
+    cluster.setPosition( math::XYZPoint(x,y,z)/energy );
+    cluster.setEnergyLow(energyLow);
+    cluster.setEnergyHigh(energyHigh);
+    cluster.setEnergy(energy);
+    //    std::cout << "layer = " << cluster.layer() << "\t cluster energy = " << energy << "\t nhit = " << clusterDetIDs.size() << std::endl;
+    for( std::vector<HGCalTBDetId>::iterator jt=clusterDetIDs.begin(); jt!=clusterDetIDs.end(); ++jt)
+      cluster.addHitAndFraction( (*jt), (*rechits.find(*jt)).energy()/energy );
+  
+    clusterCol.push_back(cluster);
+  }
+}
+
+void HGCalTBClusterProducer::buildCluster(  HGCalTBRecHitCollection rechits,
+					    std::vector<HGCalTBDetId> &temp,
+					    std::vector<HGCalTBDetId> &clusterDetIDs
+					    )
+{
+  HGCalTBTopology top;
+  HGCalTBDetId detID=clusterDetIDs.back();
+  bool  reversedlayer = std::find( _reversedLayers.begin(), _reversedLayers.end(), detID.layer() )==_reversedLayers.end() ? false : true ;
+  std::set<HGCalTBDetId> neighbors=top.getNeighboringCellsDetID( detID, _sensorSize , _maxTransverse, reversedlayer );
+  for( std::set<HGCalTBDetId>::const_iterator it=neighbors.begin(); it!=neighbors.end(); ++it){
+    if( std::find(temp.begin(), temp.end(), (*it))!=temp.end() || rechits.find(*it)==rechits.end() )
+      continue;
+    temp.push_back( (*it) );
+    clusterDetIDs.push_back( (*it) );
+    buildCluster(rechits, temp, clusterDetIDs);
+  }
+}
+
+void HGCalTBClusterProducer::createSeededClusters(HGCalTBRecHitCollection rechits, reco::HGCalTBCluster &cluster, int maxDist)
+{
+  if( rechits.size()==0 ) return;
+  _maxTransverse=maxDist;
+  HGCalTBTopology top;
+  HGCalTBRecHit seed=(*rechits.begin());
+  for( std::vector<HGCalTBRecHit>::iterator it=rechits.begin(); it!=rechits.end(); ++it){
+    if( (*it).energy() > seed.energy() )
+      seed=(*it);
+  }
+  cluster.setLayer( seed.id().layer() );
+  cluster.setSeed( seed.id() );
+  float energyHigh=seed.energyHigh();
+  float energyLow=seed.energyLow();
+  float energy=seed.energy();
+  HGCalTBCellVertices cellVertice;
+  std::pair<double, double> CellCentreXY;
+  CellCentreXY=cellVertice.GetCellCentreCoordinatesForPlots( seed.id().layer(), seed.id().sensorIU(), seed.id().sensorIV(), seed.id().iu(), seed.id().iv(), _sensorSize);
+  float x = CellCentreXY.first*seed.energy();
+  float y = CellCentreXY.second*seed.energy();
+  float z = _layerZPositions.at( seed.id().layer()-1 );
+  
+  std::set<HGCalTBDetId> neighbors=top.getNeighboringCellsDetID( seed.id(), _sensorSize , _maxTransverse );
+  for( std::set<HGCalTBDetId>::iterator jt=neighbors.begin(); jt!=neighbors.end(); ++jt){
+    if( rechits.find(*jt) != rechits.end() ){
+      HGCalTBRecHit hit=(*rechits.find(*jt));
+      energyHigh+=hit.energyHigh();
+      energyLow+=hit.energyLow();
+      energy+=hit.energy();
+      CellCentreXY=cellVertice.GetCellCentreCoordinatesForPlots( (*jt).layer(), (*jt).sensorIU(), (*jt).sensorIV(), (*jt).iu(), (*jt).iv(), _sensorSize);
+      x += CellCentreXY.first*hit.energy();
+      y += CellCentreXY.second*hit.energy();
+    }
+  }
+  cluster.setPosition( math::XYZPoint(x/energy,y/energy,z) );
+  cluster.setEnergyLow(energyLow);
+  cluster.setEnergyHigh(energyHigh);
+  cluster.setEnergy(energy);
+
+  cluster.addHitAndFraction( seed.id(), seed.energy()/energy );
+  for( std::set<HGCalTBDetId>::iterator jt=neighbors.begin(); jt!=neighbors.end(); ++jt)
+    if( rechits.find(*jt) != rechits.end() )
+      cluster.addHitAndFraction( (*jt), (*rechits.find(*jt)).energy()/energy );
+  
+}
+
+DEFINE_FWK_MODULE(HGCalTBClusterProducer);

--- a/Reco/plugins/HGCalTBClusterProducer.h
+++ b/Reco/plugins/HGCalTBClusterProducer.h
@@ -1,0 +1,49 @@
+#ifndef HGCALTBCLUSTERPRODUCER_H
+#define HGCALTBCLUSTERPRODUCER_H
+/** \class Reco/plugins/HGCalTBClusterProducer.h 
+	\brief
+
+	\author Arnaud Steen
+ */
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "HGCal/DataFormats/interface/HGCalTBRecHitCollections.h"
+#include "HGCal/DataFormats/interface/HGCalTBDetId.h"
+#include "HGCal/DataFormats/interface/HGCalTBClusterCollection.h"
+
+#include <iostream>
+
+class HGCalTBClusterProducer : public edm::EDProducer
+{
+
+public:
+	HGCalTBClusterProducer(const edm::ParameterSet&);
+	virtual void produce(edm::Event&, const edm::EventSetup&);
+private:
+	std::string _outputCollectionName;
+	std::string _outputCollectionName7;
+	std::string _outputCollectionName19;
+	edm::EDGetTokenT<HGCalTBRecHitCollection> _rechitToken;
+	
+	bool _runDynamicCluster;
+	bool _runCluster7;
+	bool _runCluster19;
+	int _sensorSize;
+	int _maxTransverse;
+	double _minEnergy;
+
+	std::vector<double> _layerZPositions;
+	std::vector<int> _reversedLayers;
+
+	void buildCluster(HGCalTBRecHitCollection rechits, std::vector<HGCalTBDetId> &temp, std::vector<HGCalTBDetId> &clusterDetIDs);
+	void createDynamicClusters(HGCalTBRecHitCollection rechits, std::vector<reco::HGCalTBCluster> &clusterCol);
+	void createSeededClusters(HGCalTBRecHitCollection rechits, reco::HGCalTBCluster &cluster, int maxDist);
+};
+
+#endif

--- a/Reco/plugins/HGCalTBClusterProducer.h
+++ b/Reco/plugins/HGCalTBClusterProducer.h
@@ -16,6 +16,7 @@
 #include "HGCal/DataFormats/interface/HGCalTBRecHitCollections.h"
 #include "HGCal/DataFormats/interface/HGCalTBDetId.h"
 #include "HGCal/DataFormats/interface/HGCalTBClusterCollection.h"
+#include "HGCal/CondObjects/interface/HGCalElectronicsMap.h"
 
 #include <iostream>
 
@@ -26,10 +27,12 @@ public:
 	HGCalTBClusterProducer(const edm::ParameterSet&);
 	virtual void produce(edm::Event&, const edm::EventSetup&);
 private:
+	std::string _elecMapFile;
 	std::string _outputCollectionName;
 	std::string _outputCollectionName7;
 	std::string _outputCollectionName19;
 	edm::EDGetTokenT<HGCalTBRecHitCollection> _rechitToken;
+	HGCalElectronicsMap _elecMap;
 	
 	bool _runDynamicCluster;
 	bool _runCluster7;
@@ -39,7 +42,6 @@ private:
 	double _minEnergy;
 
 	std::vector<double> _layerZPositions;
-	std::vector<int> _reversedLayers;
 
 	void buildCluster(HGCalTBRecHitCollection rechits, std::vector<HGCalTBDetId> &temp, std::vector<HGCalTBDetId> &clusterDetIDs);
 	void createDynamicClusters(HGCalTBRecHitCollection rechits, std::vector<reco::HGCalTBCluster> &clusterCol);

--- a/Reco/python/hgcaltbclusterproducer_cfi.py
+++ b/Reco/python/hgcaltbclusterproducer_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+hgcaltbclusters = cms.EDProducer("HGCalTBClusterProducer",
+                                 OutputCollectionName = cms.string(''),
+                                 rechitCollection = cms.InputTag('hgcaltbrechits',"","unpack"),
+                                 LayerZPositions= cms.untracked.vdouble(0.0, 4.67, 9.84, 14.27, 19.25, 20.4, 25.8, 31.4),#cern config 2
+                                 #LayerZPositions= cms.untracked.vdouble(0.0, 5.35, 10.52, 14.44, 18.52, 19.67, 23.78, 25.92),#cern config 1
+                                 reversedLayers = cms.untracked.vint32(5,7),
+                                 minEnergy = cms.untracked.double(0)
+                                 )

--- a/Reco/python/hgcaltbclusterproducer_cfi.py
+++ b/Reco/python/hgcaltbclusterproducer_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 hgcaltbclusters = cms.EDProducer("HGCalTBClusterProducer",
+                                 ElectronicMapFile = cms.untracked.string('HGCal/CondObjects/data/map_CERN_8Layers_Sept2016.txt'),
                                  OutputCollectionName = cms.string(''),
                                  rechitCollection = cms.InputTag('hgcaltbrechits',"","unpack"),
                                  LayerZPositions= cms.untracked.vdouble(0.0, 4.67, 9.84, 14.27, 19.25, 20.4, 25.8, 31.4),#cern config 2
                                  #LayerZPositions= cms.untracked.vdouble(0.0, 5.35, 10.52, 14.44, 18.52, 19.67, 23.78, 25.92),#cern config 1
-                                 reversedLayers = cms.untracked.vint32(5,7),
-                                 minEnergy = cms.untracked.double(0)
+                                  minEnergy = cms.untracked.double(100)
                                  )

--- a/Reco/python/hgcaltbrechitplotter_cfi.py
+++ b/Reco/python/hgcaltbrechitplotter_cfi.py
@@ -43,3 +43,12 @@ LayerSumAnalyzer = cms.EDAnalyzer("Layer_Sum_Analyzer",
                                   mapFile_CERN = cms.string('HGCal/CondObjects/data/map_CERN_8Layers_Sept2016.txt'),
                                   mapFile_FNAL = cms.string('')
                               )
+
+hgcaltbeventdisplay = cms.EDAnalyzer("EventDisplay",
+                                     HGCALTBCLUSTERS = cms.InputTag("hgcaltbclusters","","unpack" ),
+                                     HGCALTBCLUSTERS7 = cms.InputTag("hgcaltbclusters","7","unpack" ),
+                                     HGCALTBCLUSTERS19 = cms.InputTag("hgcaltbclusters","19","unpack" ),
+                                     Nlayers = cms.untracked.int32( 8 ),
+                                     SensorSize = cms.untracked.int32( 128 )
+                                     )
+

--- a/StandardSequences/python/LocalReco_cff.py
+++ b/StandardSequences/python/LocalReco_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from HGCal.Reco.hgcaltbrechitproducer_cfi import *
+from HGCal.Reco.hgcaltbclusterproducer_cfi import *
 
 LocalRecoSeq  = cms.Sequence(hgcaltbrechits)
+ClusterRecoSeq  = cms.Sequence(hgcaltbclusters)
 

--- a/test_cfg_newEB.py
+++ b/test_cfg_newEB.py
@@ -140,6 +140,8 @@ elif (options.chainSequence == 5):
     process.TFileService = cms.Service("TFileService", fileName = cms.string("%s/%s_Output_%06d_Reco.root"%(options.outputFolder,options.runType,options.runNumber)))
 elif (options.chainSequence == 6):
     process.TFileService = cms.Service("TFileService", fileName = cms.string("%s/%s_Output_%06d_Reco_Cluster.root"%(options.outputFolder,options.runType,options.runNumber)))
+elif (options.chainSequence == 7):
+    process.TFileService = cms.Service("TFileService", fileName = cms.string("%s/%s_Output_%06d_Display_Cluster.root"%(options.outputFolder,options.runType,options.runNumber)))
 
 
 
@@ -181,5 +183,9 @@ elif (options.chainSequence == 5):
     process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbrechitsplotter_highgain_correlation_cm)
 elif (options.chainSequence == 6):
     process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.LayerSumAnalyzer)
+elif (options.chainSequence == 7):
+    process.p =cms.Path(process.hgcaltbdigis*process.hgcaltbrechits*process.hgcaltbclusters*process.hgcaltbeventdisplay)
+# example for running display :
+# cmsRun test_cfg_newEB.py runNumber=1291 runType=HGCRun nSpills=1 dataFolder='./' pedestalsHighGain="./CondObjects/data/pedHighGain1200.txt" pedestalsLowGain="./CondObjects/data/pedLowGain1200.txt" chainSequence=7 maxEvents=10
 
 process.end = cms.EndPath(process.output)


### PR DESCRIPTION
Hi, 

I created an EDProducer for the clustering (in Reco/plugins/HGCalTBClusterProducer.cc (.h) ). The producer is by default creating 3 collections of clusters. The first collection collection corresponds to the dynamic clusters (seedless + recursive method). The second and third collections are the cluster 7 and 19.

The cluster objects HGCalTBCluster and HGCalTBClusterCollection are implemented in DataFormats.
I had to update DataFormats/src/classes.h and classes_def.xml to be able to write cluster collections in edm files.
I have also updated HGCalTBTopology.cc (.h) for the cluster construction.

 An example of how to use the output clusters is shown in Reco/plugins/EventDisplay.cc .

