### PR TITLE
New rec hit format

### DIFF
--- a/DataFormats/interface/HGCalTBRecHit.h
+++ b/DataFormats/interface/HGCalTBRecHit.h
@@ -22,14 +22,16 @@ public:
 	enum Flags {
 		kGood = 0,
 		kHighGainSaturated,
-		kLowGainSaturated
+		kLowGainSaturated,
+		kTotGainSaturated,
+		kThirdSample
 	};
 
 
 	HGCalTBRecHit();
 	// by default a recHit is greated with no flag
 	//	HGCalTBRecHit(const DetId& id, float energyLow, float energyHigh, float time, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
-	HGCalTBRecHit(const DetId& id, float energy, float energyLow, float energyHigh, float time, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
+	HGCalTBRecHit(const DetId& id, float energy, float energyLow, float energyHigh, float energyToT, float time, uint32_t flags = 0); // when constructing from digis using 2 gains for the ADC
 	
 	/// get the id
 	HGCalTBDetId id() const
@@ -37,9 +39,11 @@ public:
 		return HGCalTBDetId(detid());
 	};
 	/////  bool isRecovered() const;
-	float _energyLow, _energyHigh;
+	float _energyLow, _energyHigh, _energyTot;
 	float cellCenter_x;
 	float cellCenter_y;
+	float _time;
+
 
 	float energyLow() const
 	{
@@ -50,6 +54,17 @@ public:
 	{
 		return _energyHigh;
 	};
+
+	float energyTot() const
+	{
+		return _energyTot;
+	};
+
+	void setTime(float time);
+
+	float time(){ 
+	  return _time; 
+	} 
 
 	// set the flags
 	void setFlag(int flag)

--- a/DataFormats/src/HGCalTBRecHit.cc
+++ b/DataFormats/src/HGCalTBRecHit.cc
@@ -1,4 +1,6 @@
 #include "HGCal/DataFormats/interface/HGCalTBRecHit.h"
+#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+
 #include <iostream>
 #include <cassert>
 #include <math.h>
@@ -8,13 +10,20 @@ HGCalTBRecHit::HGCalTBRecHit() : CaloRecHit()
 }
 
 
-HGCalTBRecHit::HGCalTBRecHit(const DetId& id, float energy, float energyLow, float energyHigh, float time, uint32_t flags) :
-	CaloRecHit(id, energy, time, flags),
-	_energyLow(energyLow),
-	_energyHigh(energyHigh),
+HGCalTBRecHit::HGCalTBRecHit(const DetId& id, float energy, float energyLow, float energyHigh, float energyTot, float time, uint32_t flags) :
+  CaloRecHit(id, energy, time, flags),
+  _energyLow(energyLow),
+  _energyHigh(energyHigh),
+  _energyTot(energyTot),
   cellCenter_x(0),
   cellCenter_y(0)
 {
+}
+
+
+void HGCalTBRecHit::setTime(float time){
+  _time = time;
+  return;
 }
 
 void HGCalTBRecHit::setCellCenterCoordinate(float x, float y) {
@@ -36,6 +45,6 @@ float HGCalTBRecHit::getCellCenterCartesianCoordinate(int index) {
 
 std::ostream& operator<<(std::ostream& s, const HGCalTBRecHit& hit)
 {
-	return s << hit.id() << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
+  return s << hit.id() << ": " << hit.energy() << " GeV, " << hit._time << " ns";
 
 }

--- a/RawToDigi/plugins/HGCalTBGenSimSource.cc
+++ b/RawToDigi/plugins/HGCalTBGenSimSource.cc
@@ -178,7 +178,7 @@ void HGCalTBGenSimSource::produce(edm::Event & event)
 		std::pair<int, int> iuiv = TheCell.GetCellIUIVCoordinates(x, y);
 
 
-		HGCalTBRecHit recHit(HGCalTBDetId(layer, 0, 0, iuiv.first, iuiv.second, cellType), 0., 0., 0., 0); 
+		HGCalTBRecHit recHit(HGCalTBDetId(layer, 0, 0, iuiv.first, iuiv.second, cellType), 0., 0., 0., 0., 0); 
 			
 		/* Back and forth computation, if correct: Numbers should be identical!
 		std::pair<double, double> CellCenterXY = TheCell.GetCellCentreCoordinatesForPlots((recHit.id()).layer(), (recHit.id()).sensorIU(), (recHit.id()).sensorIV(), (recHit.id()).iu(), (recHit.id()).iv(), 128); 	//TODO: Hard Coded Number!
@@ -206,6 +206,7 @@ void HGCalTBGenSimSource::produce(edm::Event & event)
 	 	recHit.setEnergy(energy);
 	 	recHit._energyLow = energy;
 	 	recHit._energyHigh = energy;
+	 	recHit._energyTot = energy;
 
 		rechits->push_back(recHit);
 	}	

--- a/RawToDigi/plugins/HGCalTBGenSimSource_Only.cc
+++ b/RawToDigi/plugins/HGCalTBGenSimSource_Only.cc
@@ -92,7 +92,7 @@ void HGCalTBGenSimSource_Only::produce(edm::Event & event)
 		int cellType = geomc->cellType(cellno);
 		std::pair<int, int> iuiv = TheCell.GetCellIUIVCoordinates(x, y);
 
-		HGCalTBRecHit recHit(HGCalTBDetId(layer, 0, 0, iuiv.first, iuiv.second, cellType), 0., 0., 0., 0); 
+		HGCalTBRecHit recHit(HGCalTBDetId(layer, 0, 0, iuiv.first, iuiv.second, cellType), 0., 0., 0., 0., 0); 
 			
 		recHit.setCellCenterCoordinate(x, y);
 	
@@ -104,6 +104,7 @@ void HGCalTBGenSimSource_Only::produce(edm::Event & event)
 	 	recHit.setEnergy(energy);
 	 	recHit._energyLow = energy;
 	 	recHit._energyHigh = energy;
+	 	recHit._energyTot = energy;
 
 		rechits->push_back(recHit);
 	}	

--- a/Reco/BuildFile.xml
+++ b/Reco/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="HGCal/DataFormats"/>
 <use name="Alignment/ReferenceTrajectories"/>
 <use name="Alignment/MillePedeAlignmentAlgorithm"/>
+<use name="DataFormats/CaloRecHit"/>
 <export>
    <lib name="1"/>
 </export>

--- a/Reco/plugins/HGCalTBRecHitProducer.h
+++ b/Reco/plugins/HGCalTBRecHitProducer.h
@@ -8,12 +8,16 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
+#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+#include "HGCal/DataFormats/interface/HGCalTBRecHit.h"
 #include "HGCal/DataFormats/interface/HGCalTBRecHitCollections.h"
 #include "HGCal/DataFormats/interface/HGCalTBDetId.h"
 #include "HGCal/DataFormats/interface/HGCalTBRawHitCollection.h"
 #include "HGCal/CondObjects/interface/HGCalElectronicsMap.h"
 #include "HGCal/CondObjects/interface/HGCalCondObjectTextIO.h"
 #include "HGCal/DataFormats/interface/HGCalTBElectronicsId.h"
+
+#include "HGCal/Geometry/interface/HGCalTBCellVertices.h"
 
 class HGCalTBRecHitProducer : public edm::EDProducer
 {
@@ -31,6 +35,10 @@ class HGCalTBRecHitProducer : public edm::EDProducer
   edm::EDGetTokenT<HGCalTBRawHitCollection> m_HGCalTBRawHitCollection;
   std::vector<double> m_LG2HG_value;
   std::vector<double> m_TOT2LG_value;
+
+
+  std::pair<double, double> CellCentreXY;
+  HGCalTBCellVertices TheCell;
 
   struct {
     HGCalElectronicsMap emap_;

--- a/Reco/plugins/RecHitsNtuplizer.cc
+++ b/Reco/plugins/RecHitsNtuplizer.cc
@@ -1,0 +1,292 @@
+#include <iostream>
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH2Poly.h"
+#include "TTree.h"
+#include <fstream>
+#include <sstream>
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "HGCal/DataFormats/interface/HGCalTBRawHitCollection.h"
+#include "HGCal/DataFormats/interface/HGCalTBDetId.h"
+#include "HGCal/CondObjects/interface/HGCalElectronicsMap.h"
+#include "HGCal/CondObjects/interface/HGCalCondObjectTextIO.h"
+#include "HGCal/DataFormats/interface/HGCalTBElectronicsId.h"
+#include "HGCal/Geometry/interface/HGCalTBCellVertices.h"
+#include "HGCal/Reco/interface/PulseFitter.h"
+
+#include <iomanip>
+#include <set>
+#include <vector>
+
+#ifdef __MAKECINT__
+#pragma link C++ class vector<float>+;
+#endif
+
+
+const static size_t N_HEXABOARDS = 1;
+const static size_t N_SKIROC_PER_HEXA = 4;
+const static size_t N_CHANNELS_PER_SKIROC = 64;
+static const double deltaCellBoundary = 0.00001;
+const static int SENSORSIZE = 128;
+
+class RecHitsNtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources>
+{
+public:
+  explicit RecHitsNtuplizer(const edm::ParameterSet&);
+  ~RecHitsNtuplizer();
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void initTree();
+
+private:
+  virtual void beginJob() override;
+  void analyze(const edm::Event& , const edm::EventSetup&) override;
+  virtual void endJob() override;
+
+  std::string m_electronicMap;
+  struct {
+    HGCalElectronicsMap emap_;
+  } essource_;
+  double m_commonModeThreshold; //number of sigmas from ped mean
+
+  std::pair<double, double> CellCentreXY;
+  HGCalTBCellVertices TheCell;
+
+
+  int m_evtID;
+  edm::EDGetTokenT<HGCalTBRawHitCollection> m_HGCalTBRawHitCollection;
+
+  struct commonModeNoise{
+    commonModeNoise():fullHG(0),halfHG(0),mouseBiteHG(0),outerHG(0),fullLG(0),halfLG(0),mouseBiteLG(0),outerLG(0),fullCounter(0),halfCounter(0),mouseBiteCounter(0),outerCounter(0){;}
+    float fullHG,halfHG,mouseBiteHG,outerHG;
+    float fullLG,halfLG,mouseBiteLG,outerLG;
+    int fullCounter,halfCounter,mouseBiteCounter,outerCounter;
+  };
+
+  TTree* tree;
+  edm::Service<TFileService> fs;
+  std::vector<double> tsHG;
+  std::vector<double> tsLG;
+  Float_t posX;
+  Float_t posY;
+  Float_t ampHG;
+  Float_t ampLG;
+  Float_t ampTOT;
+  Float_t startTHG;
+  Float_t startTLG;
+  Float_t toaR;
+  Float_t toaF;
+  Int_t nHexB;
+  Int_t nSki;
+  Int_t nCha;
+  Int_t nEvt;
+  Int_t nRun;
+};
+
+RecHitsNtuplizer::RecHitsNtuplizer(const edm::ParameterSet& iConfig) :
+  m_electronicMap(iConfig.getUntrackedParameter<std::string>("ElectronicMap","HGCal/CondObjects/data/map_CERN_Hexaboard_OneLayers_May2017.txt")),
+  m_commonModeThreshold(iConfig.getUntrackedParameter<double>("CommonModeThreshold",100))
+{
+  m_HGCalTBRawHitCollection = consumes<HGCalTBRawHitCollection>(iConfig.getParameter<edm::InputTag>("InputCollection"));
+  m_evtID=0;
+  std::cout << iConfig.dump() << std::endl;
+
+  usesResource("TFileService");
+  tree = new TTree("hgcRH","");
+ 
+  tree->Branch("tsHG",&tsHG);
+  tree->Branch("tsLG",&tsLG);
+  tree->Branch("posX",&posX,"posX/F");
+  tree->Branch("posY",&posY,"posY/F");
+  tree->Branch("ampHG",&ampHG,"ampHG/F");
+  tree->Branch("ampLG",&ampLG,"ampLG/F");
+  tree->Branch("ampTOT",&ampLG,"ampTOT/F");
+  tree->Branch("startTHG",&startTHG,"startTHG/F");
+  tree->Branch("startTLG",&startTLG,"startTLG/F");
+  tree->Branch("toaR",&toaR,"toaR/F");
+  tree->Branch("toaF",&toaF,"toaF/F");
+  tree->Branch("nHexB",&nHexB,"nHexB/I");
+  tree->Branch("nSki",&nSki,"nSki/I");
+  tree->Branch("nCha",&nCha,"nCha/I");
+  tree->Branch("nEvt",&nEvt,"nEvt/I");
+  tree->Branch("nRun",&nRun,"nRun/I");
+
+}
+
+
+RecHitsNtuplizer::~RecHitsNtuplizer()
+{
+
+}
+
+void RecHitsNtuplizer::beginJob()
+{
+  HGCalCondObjectTextIO io(0);
+  edm::FileInPath fip(m_electronicMap);
+  if (!io.load(fip.fullPath(), essource_.emap_)) {
+    throw cms::Exception("Unable to load electronics map");
+  };
+}
+
+void RecHitsNtuplizer::initTree()
+{
+  tsHG.clear();
+  tsLG.clear();
+  posX = -1.;
+  posY = -1.;
+  ampHG = -1.;
+  ampLG = -1.;
+  ampTOT = -1.;
+  startTHG = -1.;
+  startTLG = -1.;
+  toaR = -1.;
+  toaF = -1.;
+  nHexB = -1.;
+  nSki = -1.;
+  nCha = -1.;
+  nEvt = -1.;
+  nRun = -1.;
+
+}
+
+
+void RecHitsNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& setup)
+{
+  initTree();
+
+
+  nEvt = event.id().event();
+  nRun = event.id().run();
+  
+  edm::Handle<HGCalTBRawHitCollection> hits;
+  event.getByToken(m_HGCalTBRawHitCollection, hits);
+  
+  commonModeNoise cm[NUMBER_OF_TIME_SAMPLES-0][4];
+  for( auto hit : *hits ){
+    int iski=hit.skiroc();
+    if( !essource_.emap_.existsDetId(hit.detid()) ) continue;
+    for( size_t it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+      if( hit.highGainADC(it)>m_commonModeThreshold ) continue;
+      float highGain = hit.highGainADC(it);
+      float lowGain = hit.lowGainADC(it);
+      switch ( hit.detid().cellType() ){
+      case 0 : cm[it][iski].fullHG += highGain; cm[it][iski].fullLG += lowGain; cm[it][iski].fullCounter++; break;
+      case 2 : cm[it][iski].halfHG += highGain; cm[it][iski].halfLG += lowGain; cm[it][iski].halfCounter++; break;
+      case 3 : cm[it][iski].mouseBiteHG += highGain; cm[it][iski].mouseBiteLG += lowGain; cm[it][iski].mouseBiteCounter++; break;
+      case 4 : cm[it][iski].outerHG += highGain; cm[it][iski].outerLG += lowGain; cm[it][iski].outerCounter++; break;
+      }
+    }
+  }
+  
+  for( auto hit : *hits ){
+    toaR = hit.toaRise();
+    toaF = hit.toaFall();
+
+    if(toaR == 4.) continue;
+
+    int iboard = hit.skiroc()/N_SKIROC_PER_HEXA;
+    int iski = hit.skiroc();
+    int ichan = hit.channel();
+
+    nHexB = 1000*iboard;
+    nSki = 100*iski;
+    nCha = ichan;
+
+
+    if( essource_.emap_.existsDetId(hit.detid()) ){
+      float highGain, lowGain;
+      std::vector<double> sampleT;
+      sampleT.clear();
+      tsHG.clear();
+      tsLG.clear();
+      ampTOT = hit.totSlow();
+
+      float subHG[NUMBER_OF_TIME_SAMPLES],subLG[NUMBER_OF_TIME_SAMPLES];
+      for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+      	subHG[it]=0;
+      	subLG[it]=0;
+      }
+      switch ( hit.detid().cellType() ){
+      case 0 : 
+      	for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+      	  subHG[it]=cm[it][iski].fullCounter>0 ? cm[it][iski].fullHG/cm[it][iski].fullCounter : 0; 
+      	  subLG[it]=cm[it][iski].fullCounter>0 ? cm[it][iski].fullLG/cm[it][iski].fullCounter : 0; 
+      	}
+      	break;
+      case 2 : 
+      	for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+      	  subHG[it]=cm[it][iski].halfCounter>0 ? cm[it][iski].halfHG/cm[it][iski].halfCounter : 0; 
+      	  subLG[it]=cm[it][iski].halfCounter>0 ? cm[it][iski].halfLG/cm[it][iski].halfCounter : 0; 
+      	}
+      	break;
+      case 3 : 
+      	for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+      	  subHG[it]=cm[it][iski].mouseBiteCounter>0 ? cm[it][iski].mouseBiteHG/cm[it][iski].mouseBiteCounter : 0; 
+      	  subLG[it]=cm[it][iski].mouseBiteCounter>0 ? cm[it][iski].mouseBiteLG/cm[it][iski].mouseBiteCounter : 0; 
+      	}
+      	break;
+      case 4 : for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+       	  subHG[it]=cm[it][iski].outerCounter>0 ? cm[it][iski].outerHG/cm[it][iski].outerCounter : 0; 
+       	  subLG[it]=cm[it][iski].outerCounter>0 ? cm[it][iski].outerLG/cm[it][iski].outerCounter : 0; 
+       	}
+       	break;
+      }
+      for( int it=0; it<NUMBER_OF_TIME_SAMPLES; it++ ){
+	highGain = hit.highGainADC(it)-subHG[it];
+	lowGain = hit.lowGainADC(it)-subLG[it];
+	
+	tsHG.push_back(highGain);
+	tsLG.push_back(lowGain);
+	sampleT.push_back(it*25);
+      }
+      //this is a just try to isolate hits with signal 
+      float en2=hit.highGainADC(2)-subHG[2];
+      float en3=hit.highGainADC(3)-subHG[3];
+      float en4=hit.highGainADC(4)-subHG[4];
+      float en6=hit.highGainADC(6)-subHG[6];
+
+
+      if(en2<en3 && en3>en6 && en4>en6 && en3>20){
+	PulseFitter fitter(0,150);
+	PulseFitterResult fithg;
+	fitter.run(sampleT, tsHG, fithg);
+	PulseFitterResult fitlg;
+	fitter.run(sampleT, tsLG, fitlg);
+	
+	ampHG = fithg.amplitude;
+	ampLG = fitlg.amplitude;
+	startTHG = fithg.tmax - fithg.trise;
+	startTLG = fitlg.tmax - fitlg.trise;	
+      }
+
+      HGCalTBDetId detid = hit.detid();
+      CellCentreXY = TheCell.GetCellCentreCoordinatesForPlots(detid.layer(), detid.sensorIU(), detid.sensorIV(), detid.iu(), detid.iv(), SENSORSIZE );
+      posX = (CellCentreXY.first < 0 ) ? (CellCentreXY.first + deltaCellBoundary) : (CellCentreXY.first - deltaCellBoundary);
+      posY = (CellCentreXY.second < 0 ) ? (CellCentreXY.second + deltaCellBoundary) : (CellCentreXY.second - deltaCellBoundary);      
+    }
+    if(startTHG > 0. && startTLG > 0.) tree->Fill();
+  }
+  m_evtID++;
+}
+
+void RecHitsNtuplizer::endJob()
+{
+}
+
+void RecHitsNtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(RecHitsNtuplizer);

--- a/run2017_cfg.py
+++ b/run2017_cfg.py
@@ -12,7 +12,7 @@ options.register('dataFolder',
                  'folder containing raw input')
 
 options.register('runNumber',
-                 850,
+                 106,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  'Input run to process')
@@ -95,6 +95,14 @@ process.pulseshapeplotter = cms.EDAnalyzer("PulseShapePlotter",
                                            )
 
 
+
+process.recHitNtuplizer = cms.EDAnalyzer("RecHitsNtuplizer",
+                                         InputCollection=cms.InputTag("rawhitproducer","HGCALTBRAWHITS"),
+                                         ElectronicMap=cms.untracked.string("HGCal/CondObjects/data/map_CERN_Hexaboard_OneLayers_May2017.txt"),
+                                         CommonModeThreshold=cms.untracked.double(100)
+                                         )
+
+
 process.rechitproducer = cms.EDProducer("HGCalTBRecHitProducer",
                                         OutputCollectionName = cms.string('HGCALTBRECHITS'),
                                         InputCollection = cms.InputTag('rawhitproducer','HGCALTBRAWHITS'),
@@ -104,7 +112,7 @@ process.rechitproducer = cms.EDProducer("HGCalTBRecHitProducer",
                                         LowGainADCSaturation = cms.untracked.double(1800),
                                         ElectronicsMap = cms.untracked.string('HGCal/CondObjects/data/map_CERN_Hexaboard_OneLayers_May2017.txt'),
                                         CommonModeThreshold = cms.untracked.double(100.),
-                                        KeepOnlyTimeSample3 = cms.untracked.bool(True)
+                                        KeepOnlyTimeSample3 = cms.untracked.bool(False)
                                         )
 
 process.rechitplotter = cms.EDAnalyzer("RecHitPlotter",
@@ -119,6 +127,8 @@ process.rechitplotter = cms.EDAnalyzer("RecHitPlotter",
 #process.p = cms.Path( process.rawdataplotter )
 #process.p = cms.Path( process.rawhitproducer*process.rawhitplotter*process.rawdataplotter )
 #process.p = cms.Path( process.rawhitproducer*process.rawhitplotter*process.pulseshapeplotter )
+#process.p = cms.Path( process.rawhitproducer*process.recHitNtuplizer )
+#process.p = cms.Path( process.rawhitproducer*process.rechitproducer)
 process.p = cms.Path( process.rawhitproducer*process.rechitproducer*process.rechitplotter*process.rawhitplotter )
 
 process.end = cms.EndPath(process.output)


### PR DESCRIPTION
HGCalTBRecHitProducer and HGCalTBRecHit updated to accept three gains (LG HG and TOT):
the recHit energy is assigned accordingly to the gain switch regime. Note that the threshold for saturation are still 1800 NEED TO BE studied and updated
Also added the position for each recHit

Also the ADC counts are taken from the fit of the pulse shape. Configuration through the KeepOnlyTimeSample3 = cms.untracked.bool(False)

In addition a dedicated ntuplizer is added, with the time stamps and interesting values from the fit and position and id